### PR TITLE
Add scoreboard overlay

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -50,6 +50,7 @@ export function Game({models, sounds, matchId, character}) {
     const {dispatch} = useInterface();
     const {socket, sendToSocket} = useWS(matchId);
     const [isReadyToPlay, setIsReadyToPlay] = useState(false);
+    // scoreboard visibility and data managed via interface context
 
     const account = useCurrentAccount();
     const address = account?.address;
@@ -494,6 +495,9 @@ export function Game({models, sounds, matchId, character}) {
                 case "KeyG":
                     leftMouseButtonClicked = true;
                     break;
+                case "KeyT":
+                    dispatch({type: 'SET_SCOREBOARD_VISIBLE', payload: true});
+                    break;
                 case "Space": // Press "Q" to cast shield
                     // Space for jumping
                     if (playerOnFloor && !jumpBlocked) {
@@ -537,6 +541,9 @@ export function Game({models, sounds, matchId, character}) {
             switch (event.code) {
                 case "KeyG":
                     leftMouseButtonClicked = false;
+                    break;
+                case "KeyT":
+                    dispatch({type: 'SET_SCOREBOARD_VISIBLE', payload: false});
                     break;
                 case "Space": // Press "Q" to cast shield
                     setTimeout(() => {
@@ -1811,6 +1818,13 @@ export function Game({models, sounds, matchId, character}) {
                         }
 
                     }
+
+                    const boardData = Object.entries(message.players).map(([id, p]) => ({
+                        id: Number(id),
+                        kills: p.kills,
+                        deaths: p.deaths,
+                    }));
+                    dispatch({type: 'SET_SCOREBOARD_DATA', payload: boardData});
 
                     break;
                 case "removePlayer":

--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -2,6 +2,7 @@ import {SkillBar} from "../parts/SkillBar";
 import {CastBar} from "../parts/CastBar";
 import {Chat} from "../parts/Chat";
 import {Coins} from "../parts/Coins";
+import {Scoreboard} from "../parts/Scoreboard";
 
 import './Interface.css';
 
@@ -49,6 +50,7 @@ export const Interface = () => {
                 Enter for Respawn
             </button>
 
+            <Scoreboard />
             <SkillBar/>
             <CastBar/>
             <Chat />

--- a/client/next-js/components/parts/Scoreboard.css
+++ b/client/next-js/components/parts/Scoreboard.css
@@ -1,0 +1,27 @@
+.scoreboard-overlay {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    padding: 20px;
+    border-radius: 10px;
+    z-index: 1000;
+}
+
+.scoreboard-table {
+    width: 300px;
+    border-collapse: collapse;
+}
+
+.scoreboard-table th,
+.scoreboard-table td {
+    border: 1px solid #555;
+    padding: 5px 10px;
+    text-align: left;
+}
+
+.scoreboard-table th {
+    background-color: #222;
+}

--- a/client/next-js/components/parts/Scoreboard.jsx
+++ b/client/next-js/components/parts/Scoreboard.jsx
@@ -1,0 +1,31 @@
+import {useInterface} from "../../context/inteface";
+import './Scoreboard.css';
+
+export const Scoreboard = () => {
+    const {state: {scoreboardVisible, scoreboardData}} = useInterface();
+
+    if (!scoreboardVisible) return null;
+
+    return (
+        <div className="scoreboard-overlay">
+            <table className="scoreboard-table">
+                <thead>
+                <tr>
+                    <th>Player</th>
+                    <th>Kills</th>
+                    <th>Deaths</th>
+                </tr>
+                </thead>
+                <tbody>
+                {scoreboardData.map((p) => (
+                    <tr key={p.id}>
+                        <td>{`Player ${p.id}`}</td>
+                        <td>{p.kills}</td>
+                        <td>{p.deaths}</td>
+                    </tr>
+                ))}
+                </tbody>
+            </table>
+        </div>
+    );
+};

--- a/client/next-js/context/inteface.jsx
+++ b/client/next-js/context/inteface.jsx
@@ -5,6 +5,8 @@ export const InterfaceContext = createContext(undefined);
 export const initInterfaceState = {
     chatMessages: [],
     character: null,
+    scoreboardData: [],
+    scoreboardVisible: false,
 };
 
 export const interfaceReducer = (state, action) => {
@@ -18,6 +20,12 @@ export const interfaceReducer = (state, action) => {
         }
         case 'SET_CHARACTER': {
             return {...state, character: action.payload};
+        }
+        case 'SET_SCOREBOARD_DATA': {
+            return {...state, scoreboardData: action.payload};
+        }
+        case 'SET_SCOREBOARD_VISIBLE': {
+            return {...state, scoreboardVisible: action.payload};
         }
         default:
             return {...state};


### PR DESCRIPTION
## Summary
- add scoreboard component for kills and deaths
- expose scoreboard data via Interface context
- show scoreboard on press of the T key
- style scoreboard overlay

## Testing
- `npm run lint` *(fails: Module needs an import attribute of "type: json")*

------
https://chatgpt.com/codex/tasks/task_e_6843dffe870c8329bfed96179e1a8cbe