### PR TITLE
Add match finish and summary page

### DIFF
--- a/client/next-js/app/matches/[id]/summary/page.tsx
+++ b/client/next-js/app/matches/[id]/summary/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import {useWS} from "@/hooks/useWS";
+import {useEffect, useState} from "react";
+import {Table, TableHeader, TableColumn, TableBody, TableRow, TableCell, Button} from "@heroui/react";
+import {useParams, useRouter} from "next/navigation";
+import {Navbar} from "@/components/navbar";
+
+interface PlayerSummary {
+    id: number;
+    kills: number;
+    deaths: number;
+}
+
+export default function MatchSummaryPage() {
+    const params = useParams();
+    const router = useRouter();
+    const {socket, sendToSocket} = useWS(params?.id);
+    const [summary, setSummary] = useState<PlayerSummary[]>([]);
+
+    useEffect(() => {
+        socket.onmessage = (event) => {
+            const message = JSON.parse(event.data);
+            switch (message.type) {
+                case "MATCH_SUMMARY":
+                    setSummary(message.summary);
+                    break;
+            }
+        };
+
+        sendToSocket({type: 'GET_MATCH_SUMMARY', matchId: params?.id});
+    }, []);
+
+    const back = () => router.push('/matches');
+
+    return (
+        <div className="h-full">
+            <Navbar/>
+            <div className="flex justify-center items-center">
+                <div className="max-w-[640px] min-w-[480px] flex gap-8 flex-col">
+                    <Table aria-label="Match summary">
+                        <TableHeader>
+                            <TableColumn>Player</TableColumn>
+                            <TableColumn>Kills</TableColumn>
+                            <TableColumn>Deaths</TableColumn>
+                        </TableHeader>
+                        <TableBody>
+                            {summary.map(p => (
+                                <TableRow key={p.id}>
+                                    <TableCell>{`Player ${p.id}`}</TableCell>
+                                    <TableCell>{p.kills}</TableCell>
+                                    <TableCell>{p.deaths}</TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                    <Button color="primary" onPress={back}>Back to matches</Button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -7,6 +7,7 @@ import {OctreeHelper} from "three/examples/jsm/helpers/OctreeHelper";
 import {Capsule} from "three/examples/jsm/math/Capsule";
 import {CSS2DRenderer} from "three/examples/jsm/renderers/CSS2DRenderer";
 import {useCurrentAccount} from "@mysten/dapp-kit";
+import { useRouter } from "next/navigation";
 
 import {useCoins} from "../hooks/useCoins";
 import {useInterface} from "../context/inteface";
@@ -49,6 +50,7 @@ export function Game({models, sounds, matchId, character}) {
     const {refetch: refetchCoins} = useCoins();
     const {dispatch} = useInterface();
     const {socket, sendToSocket} = useWS(matchId);
+    const router = useRouter();
     const [isReadyToPlay, setIsReadyToPlay] = useState(false);
     // scoreboard visibility and data managed via interface context
 
@@ -1829,6 +1831,9 @@ export function Game({models, sounds, matchId, character}) {
                     break;
                 case "removePlayer":
                     removePlayer(message.id);
+                    break;
+                case "MATCH_FINISHED":
+                    router.push(`/matches/${matchId}/summary`);
                     break;
                 case "MATCH_READY":
                     setIsReadyToPlay(true);


### PR DESCRIPTION
## Summary
- finish match on server after a player gets 15 kills
- expose `GET_MATCH_SUMMARY` event and broadcast `MATCH_FINISHED`
- store finished match data
- redirect client to summary page when match ends
- show match statistics in new summary page

## Testing
- `npm run lint` *(fails: Module needs an import attribute of type json)*

------
https://chatgpt.com/codex/tasks/task_e_6843e94951cc83299118a5619a0cf5a6