### PR TITLE
Implement loot bag page

### DIFF
--- a/client/next-js/app/bag/page.tsx
+++ b/client/next-js/app/bag/page.tsx
@@ -1,9 +1,81 @@
+"use client";
+
+import { Card, Button } from "@heroui/react";
+import Image from "next/image";
 import { title } from "@/components/primitives";
+import { useCoins } from "@/hooks/useCoins";
+import { useLootBoxes } from "@/hooks/useLootBoxes";
+import { useSkins } from "@/hooks/useSkins";
+import { useState } from "react";
 
 export default function BagPage() {
+  const { coins, refetch: refetchCoins } = useCoins();
+  const { lootboxes, refetch: refetchLoot } = useLootBoxes();
+  const { skins, refetch: refetchSkins } = useSkins();
+  const [opening, setOpening] = useState<string | null>(null);
+
+  const openBox = (id: string) => {
+    setOpening(id);
+    // TODO: integrate with on-chain transaction
+    setTimeout(() => {
+      refetchLoot();
+      refetchCoins();
+      refetchSkins();
+      setOpening(null);
+    }, 1000);
+  };
+
   return (
-    <div>
-      <h1 className={title()}>Docs</h1>
+    <div className="w-full h-full flex justify-center items-start p-4">
+      <Card className="w-full max-w-5xl p-6 space-y-6">
+        <h1 className={title()}>My Loot</h1>
+        <div className="text-lg font-medium">Coins: {coins}</div>
+
+        <div>
+          <h2 className="text-xl font-semibold mb-2">Loot Boxes</h2>
+          {lootboxes.length === 0 ? (
+            <p className="text-default-500">No loot boxes</p>
+          ) : (
+            <ul className="flex flex-wrap gap-4">
+              {lootboxes.map((lb: any) => {
+                const id = lb.data?.objectId || lb.reference?.objectId || lb.id;
+                return (
+                  <li key={id} className="flex flex-col items-center gap-2">
+                    <Image src="/logo_big.png" alt="Loot box" width={80} height={80} />
+                    <Button
+                      color="primary"
+                      isLoading={opening === id}
+                      onPress={() => openBox(id)}
+                    >
+                      Open
+                    </Button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        <div>
+          <h2 className="text-xl font-semibold mb-2">Skins</h2>
+          {skins.length === 0 ? (
+            <p className="text-default-500">No skins</p>
+          ) : (
+            <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+              {skins.map((skin: any) => {
+                const kind = skin.data?.content?.fields?.kind;
+                const id = skin.data?.objectId || skin.reference?.objectId || skin.id;
+                return (
+                  <li key={id} className="flex flex-col items-center">
+                    <Image src="/logo_big.png" alt={`Skin ${kind}`} width={80} height={80} />
+                    <span className="text-sm mt-1">Skin {kind}</span>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </Card>
     </div>
   );
 }

--- a/client/next-js/hooks/index.js
+++ b/client/next-js/hooks/index.js
@@ -1,1 +1,4 @@
 export * from "./useTransaction";
+export * from "./useCoins";
+export * from "./useLootBoxes";
+export * from "./useSkins";

--- a/client/next-js/hooks/useLootBoxes.ts
+++ b/client/next-js/hooks/useLootBoxes.ts
@@ -1,0 +1,21 @@
+import { useCurrentAccount, useSuiClientQuery } from "@mysten/dapp-kit";
+import { PACKAGE_ID } from "@/consts";
+
+export const useLootBoxes = () => {
+  const account = useCurrentAccount();
+
+  const { data, refetch } = useSuiClientQuery(
+    "getOwnedObjects",
+    {
+      owner: account?.address || "",
+      filter: { StructType: `${PACKAGE_ID}::lootbox::LootBox` },
+    },
+    {
+      gcTime: 10000,
+    },
+  );
+
+  const lootboxes = Array.isArray(data?.data) ? data?.data : [];
+
+  return { lootboxes, refetch };
+};

--- a/client/next-js/hooks/useSkins.ts
+++ b/client/next-js/hooks/useSkins.ts
@@ -1,0 +1,22 @@
+import { useCurrentAccount, useSuiClientQuery } from "@mysten/dapp-kit";
+import { PACKAGE_ID } from "@/consts";
+
+export const useSkins = () => {
+  const account = useCurrentAccount();
+
+  const { data, refetch } = useSuiClientQuery(
+    "getOwnedObjects",
+    {
+      owner: account?.address || "",
+      filter: { StructType: `${PACKAGE_ID}::lootbox::Skin` },
+      options: { showContent: true },
+    },
+    {
+      gcTime: 10000,
+    },
+  );
+
+  const skins = Array.isArray(data?.data) ? data?.data : [];
+
+  return { skins, refetch };
+};


### PR DESCRIPTION
## Summary
- create hooks for reading loot boxes and skins from Sui
- build `/bag` page showing coins, loot boxes and skins with HeroUI
- re-export new hooks

## Testing
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843fcab204483298e0d1d5ec5300e74