### PR TITLE
Enhance rune appearance and animation

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -1653,6 +1653,13 @@ export function Game({models, sounds, matchId, character}) {
                         mesh.position.y += 0.2;
                     });
 
+                    runes.forEach(r => {
+                        r.rotation.y += delta;
+                        if (r.userData.baseY !== undefined) {
+                            r.position.y = r.userData.baseY + Math.sin(clock.elapsedTime * 2) * 0.5;
+                        }
+                    });
+
                     // renderCursor();
                     updateCameraPosition();
                 }
@@ -1775,6 +1782,24 @@ export function Game({models, sounds, matchId, character}) {
             if (!base) return;
             const rune = SkeletonUtils.clone(base);
             rune.position.set(data.position.x, data.position.y, data.position.z);
+            rune.scale.multiplyScalar(0.2);
+
+            const colors = {
+                damage: 0xff0000,
+                heal: 0x00ff00,
+                mana: 0x0000ff,
+            };
+
+            rune.traverse((child) => {
+                if (child.isMesh) {
+                    child.material = child.material.clone();
+                    if (child.material.color) {
+                        child.material.color.setHex(colors[data.type] || 0xffffff);
+                    }
+                }
+            });
+
+            rune.userData.baseY = rune.position.y;
             scene.add(rune);
             runes.set(data.id, rune);
         }


### PR DESCRIPTION
## Summary
- improve createRune to scale runes down, add colors and store initial height
- animate runes in the render loop with rotation and bobbing

## Testing
- `npm run lint` *(fails: Module needs an import attribute)*

------
https://chatgpt.com/codex/tasks/task_e_6844bf87f9e48329bef720489b627cf0