### PR TITLE
Add Ice Veins skill with server-side haste buff

### DIFF
--- a/client/next-js/.eslintrc.json
+++ b/client/next-js/.eslintrc.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json.schemastore.org/eslintrc.json",
   "env": {
     "browser": false,
     "es2021": true,

--- a/client/next-js/components/parts/SkillBar.jsx
+++ b/client/next-js/components/parts/SkillBar.jsx
@@ -9,16 +9,16 @@ export const SkillBar = () => {
                 <div className="skill-key" id="fireball-cooldown">E</div>
             </div>
             <div className="skill-button">
-                <div className="skill-icon" style={{backgroundImage: "url('/icons/spell_frostbolt.jpg')"}}></div>
-                <div className="skill-key" id="icebolt-cooldown">R</div>
+                <div className="skill-icon" style={{backgroundImage: "url('/icons/spell_veins.jpg')"}}></div>
+                <div className="skill-key" id="ice-veins-cooldown">R</div>
             </div>
             <div className="skill-button">
                 <div className="skill-icon" style={{backgroundImage: "url('/icons/shield.png')"}}></div>
                 <div className="skill-key" id="icebolt-cooldown">Q</div>
             </div>
             <div className="skill-button">
-                <div className="skill-icon" style={{backgroundImage: "url('/icons/spell_veins.jpg')"}}></div>
-                <div className="skill-key" id="ice-veins">F</div>
+                <div className="skill-icon" style={{backgroundImage: "url('/icons/spell_frostbolt.jpg')"}}></div>
+                <div className="skill-key" id="icebolt-cooldown">F</div>
             </div>
             {/*<div className="skill-button">*/}
             {/*    <div className="skill-icon" style={{backgroundImage: "url('/icons/spell_fire_sealoffire.jpg')"}}></div>*/}

--- a/client/next-js/package.json
+++ b/client/next-js/package.json
@@ -6,7 +6,7 @@
   "dev": "next dev --turbopack",
   "build": "next build",
   "start": "next start",
-  "lint": "eslint . --ext .ts,.tsx -c .eslintrc.json --fix"
+  "lint": "npx -y eslint@8 -c .eslintrc.json . --ext .ts,.tsx --fix"
  },
  "dependencies": {
   "@gsap/react": "^2.1.2",

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -8,6 +8,7 @@ const SPELL_COST = {
     'shield': 80,
     'blink': 20,
     'heal': 30,
+    'ice-veins': 40,
 };
 
 const RUNE_POSITIONS = [
@@ -344,12 +345,16 @@ ws.on('connection', (socket) => {
                             player.hp = Math.min(100, player.hp + 20);
                         }
 
-                        if (['fireball', 'iceball', 'shield'].includes(message.payload.type)) {
+                        if (['fireball', 'iceball', 'shield', 'ice-veins'].includes(message.payload.type)) {
                             broadcastToMatch(match.id, {
                                 type: 'CAST_SPELL',
                                 payload: message.payload,
                                 id,
                             }, id);
+                        }
+
+                        if (message.payload.type === 'ice-veins') {
+                            player.buffs.push({type: 'haste', percent: 0.3, expires: Date.now() + 15000});
                         }
 
                         broadcastToMatch(match.id, {


### PR DESCRIPTION
## Summary
- map new Ice Veins skill to the `R` key in the skill bar
- support casting Ice Veins and show a rotating frost ring on the player
- reduce cast times by 30% while the haste buff is active
- broadcast Ice Veins usage from the server and apply a haste buff
- fix lint configuration for modern Node

## Testing
- `npm run lint` *(fails: cannot find required ESLint plugin)*
- `npm test` *(fails: no test script defined)*

------
https://chatgpt.com/codex/tasks/task_e_68469d61c12c832983ee21b358bbecad