### PR TITLE
Add damage sound effect

### DIFF
--- a/client/next-js/app/matches/[id]/game/page.tsx
+++ b/client/next-js/app/matches/[id]/game/page.tsx
@@ -74,6 +74,7 @@ export default function GamePage() {
             spellCast: new Audio('/sounds/spell-cast.ogg'),
             background: new Audio('/sounds/Elwynn.mp3'),
             blink: new Audio('/sounds/blink.ogg'),
+            damage: new Audio('/sounds/damage.ogg'),
         }
         preloadModels(models)
             .then((loadedModels) => {

--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -2013,6 +2013,11 @@ export function Game({models, sounds, matchId, character}) {
                 case "DAMAGE":
                     if (message.targetId) {
                         showDamage(message.targetId, message.amount);
+                        if (message.targetId === myPlayerId) {
+                            sounds.damage.volume = 0.5;
+                            sounds.damage.currentTime = 0;
+                            sounds.damage.play();
+                        }
                     }
                     break;
                 case "RUNE_PICKED":


### PR DESCRIPTION
## Summary
- preload new `damage.ogg` sound
- play damage sound when the local player is hit
- remove `public/sounds/damage.ogg` from version control

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*

------
https://chatgpt.com/codex/tasks/task_e_6846abcefd488329b978f7a438dd4c84