### PR TITLE
Add skill cooldown indicator

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -255,6 +255,21 @@ export function Game({models, sounds, matchId, character}) {
         let globalSkillCooldown = false; // Tracks if the global cooldown is active
         let isCasting = false;
         const cooldownDuration = 700; // Cooldown duration in milliseconds
+        const SKILL_COOLDOWNS = {
+            fireball: 0,
+            iceball: 0,
+            'ice-shield': 30000,
+            'ice-veins': 25000,
+            blink: 10000,
+            heal: 0,
+        };
+
+        function startSkillCooldown(skill) {
+            const duration = SKILL_COOLDOWNS[skill];
+            if (duration && duration > 0) {
+                dispatchEvent('skill-cooldown', {skill, duration});
+            }
+        }
 
         // Function to activate the cooldown
         function activateGlobalCooldown() {
@@ -719,6 +734,7 @@ export function Game({models, sounds, matchId, character}) {
 
             // Activate cooldown
             activateGlobalCooldown();
+            startSkillCooldown('blink');
         }
 
         function castHeal() {
@@ -755,6 +771,7 @@ export function Game({models, sounds, matchId, character}) {
                 isHealActive = true;
                 setTimeout(() => (isHealActive = false), 700);
                 activateGlobalCooldown(); // Activate global cooldown
+                startSkillCooldown('heal');
             };
 
             isCasting = true;
@@ -933,6 +950,7 @@ export function Game({models, sounds, matchId, character}) {
                 }
 
                 activateGlobalCooldown(); // Activate global cooldown
+                startSkillCooldown(spellType);
             };
 
             isCasting = true;

--- a/client/next-js/components/parts/SkillBar.css
+++ b/client/next-js/components/parts/SkillBar.css
@@ -34,3 +34,17 @@
     color: white;
     font-size: 14px;
 }
+
+.cooldown-overlay {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    font-size: 14px;
+}

--- a/client/next-js/components/parts/SkillBar.jsx
+++ b/client/next-js/components/parts/SkillBar.jsx
@@ -1,30 +1,73 @@
+import {useEffect, useState} from 'react';
 import './SkillBar.css';
 
+const SKILLS = [
+    {id: 'fireball', key: 'E', icon: '/icons/fireball.png'},
+    {id: 'ice-veins', key: 'R', icon: '/icons/spell_veins.jpg'},
+    {id: 'ice-shield', key: 'Q', icon: '/icons/shield.png'},
+    {id: 'iceball', key: 'F', icon: '/icons/spell_frostbolt.jpg'},
+];
+
 export const SkillBar = () => {
+    const [cooldowns, setCooldowns] = useState({});
+
+    useEffect(() => {
+        const handleCooldown = (e) => {
+            const {skill, duration} = e.detail || {};
+            if (!skill || !duration) return;
+            setCooldowns((prev) => ({
+                ...prev,
+                [skill]: {end: Date.now() + duration, duration},
+            }));
+        };
+        window.addEventListener('skill-cooldown', handleCooldown);
+        return () => window.removeEventListener('skill-cooldown', handleCooldown);
+    }, []);
+
+    useEffect(() => {
+        const interval = setInterval(() => {
+            setCooldowns((prev) => {
+                const updated = {...prev};
+                let changed = false;
+                Object.keys(updated).forEach((key) => {
+                    const remaining = updated[key].end - Date.now();
+                    if (remaining <= 0) {
+                        delete updated[key];
+                        changed = true;
+                    }
+                });
+                return changed ? updated : prev;
+            });
+        }, 100);
+        return () => clearInterval(interval);
+    }, []);
 
     return (
         <div id="skills-bar">
-            <div className="skill-button">
-                <div className="skill-icon" style={{backgroundImage: "url('/icons/fireball.png')"}}></div>
-                <div className="skill-key" id="fireball-cooldown">E</div>
-            </div>
-            <div className="skill-button">
-                <div className="skill-icon" style={{backgroundImage: "url('/icons/spell_veins.jpg')"}}></div>
-                <div className="skill-key" id="ice-veins-cooldown">R</div>
-            </div>
-            <div className="skill-button">
-                <div className="skill-icon" style={{backgroundImage: "url('/icons/shield.png')"}}></div>
-                <div className="skill-key" id="icebolt-cooldown">Q</div>
-            </div>
-            <div className="skill-button">
-                <div className="skill-icon" style={{backgroundImage: "url('/icons/spell_frostbolt.jpg')"}}></div>
-                <div className="skill-key" id="icebolt-cooldown">F</div>
-            </div>
-            {/*<div className="skill-button">*/}
-            {/*    <div className="skill-icon" style={{backgroundImage: "url('/icons/spell_fire_sealoffire.jpg')"}}></div>*/}
-            {/*    <div className="skill-key" id="heal-cooldown">F</div>*/}
-            {/*</div>*/}
+            {SKILLS.map((skill) => {
+                const data = cooldowns[skill.id];
+                let percent = 0;
+                let text = skill.key;
+                if (data) {
+                    const remaining = data.end - Date.now();
+                    percent = remaining / data.duration;
+                    text = Math.ceil(remaining / 1000);
+                }
+                return (
+                    <div className="skill-button" key={skill.id}>
+                        <div className="skill-icon" style={{backgroundImage: `url('${skill.icon}')`}}></div>
+                        {data && (
+                            <div
+                                className="cooldown-overlay"
+                                style={{height: `${Math.max(0, percent) * 100}%`}}
+                            >
+                                {text}
+                            </div>
+                        )}
+                        {!data && <div className="skill-key">{text}</div>}
+                    </div>
+                );
+            })}
         </div>
-
-    )
-}
+    );
+};


### PR DESCRIPTION
## Summary
- show skill-specific cooldowns after casting a spell
- render overlay progress in `SkillBar`
- adjust cooldown durations for each skill

## Testing
- `npm run lint` *(fails: A form label must be associated with a control)*

------
https://chatgpt.com/codex/tasks/task_e_6846abf40c088329bf015fd585efa727