### PR TITLE
Add Warlock class with Darkball spell

### DIFF
--- a/client/next-js/app/matches/[id]/page.tsx
+++ b/client/next-js/app/matches/[id]/page.tsx
@@ -87,6 +87,7 @@ export default function MatchesPage() {
                             <option value="mage">Mage</option>
                             <option value="warrior">Warrior</option>
                             <option value="archer">Archer</option>
+                            <option value="warlock">Warlock</option>
                         </select>
                     </div>
                     <div className="flex flex-col">

--- a/client/next-js/components/parts/SkillBar.jsx
+++ b/client/next-js/components/parts/SkillBar.jsx
@@ -1,14 +1,26 @@
 import {useEffect, useState} from 'react';
+import {useInterface} from '@/context/inteface';
 import './SkillBar.css';
 
-const SKILLS = [
+const DEFAULT_SKILLS = [
     {id: 'fireball', key: 'E', icon: '/icons/fireball.png'},
     {id: 'iceball', key: 'R', icon: '/icons/spell_frostbolt.jpg'},
     {id: 'fireblast', key: 'Q', icon: '/icons/spell_fire_fireball.jpg'},
     {id: 'ice-veins', key: 'F', icon: '/icons/spell_veins.jpg'},
 ];
 
+const WARLOCK_SKILLS = [
+    // Use the fireball icon until a dedicated asset is available
+    {id: 'darkball', key: 'E', icon: '/icons/fireball.png'},
+    {id: 'iceball', key: 'R', icon: '/icons/spell_frostbolt.jpg'},
+    {id: 'fireblast', key: 'Q', icon: '/icons/spell_fire_fireball.jpg'},
+    {id: 'ice-veins', key: 'F', icon: '/icons/spell_veins.jpg'},
+];
+
 export const SkillBar = () => {
+    const {state: {character}} = useInterface();
+    const skills = character?.name === 'warlock' ? WARLOCK_SKILLS : DEFAULT_SKILLS;
+
     const [cooldowns, setCooldowns] = useState({});
 
     useEffect(() => {
@@ -44,7 +56,7 @@ export const SkillBar = () => {
 
     return (
         <div id="skills-bar">
-            {SKILLS.map((skill) => {
+            {skills.map((skill) => {
                 const data = cooldowns[skill.id];
                 let percent = 0;
                 let text = skill.key;

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -4,6 +4,7 @@ const http = require('http');
 const UPDATE_MATCH_INTERVAL = 33;
 const SPELL_COST = {
     'fireball': 25,
+    'darkball': 25,
     'iceball': 25,
     'fireblast': 20,
     'shield': 80,
@@ -346,7 +347,7 @@ ws.on('connection', (socket) => {
                             player.hp = Math.min(100, player.hp + 20);
                         }
 
-                        if (['fireball', 'iceball', 'shield', 'ice-veins', 'fireblast'].includes(message.payload.type)) {
+                        if (['fireball', 'darkball', 'iceball', 'shield', 'ice-veins', 'fireblast'].includes(message.payload.type)) {
                             broadcastToMatch(match.id, {
                                 type: 'CAST_SPELL',
                                 payload: message.payload,


### PR DESCRIPTION
## Summary
- add `darkball` spell server-side and broadcast logic
- update SkillBar to show warlock skills
- hook `KeyE` to cast darkball for warlocks
- add Darkball projectile visuals
- expose Warlock in class selection
- remove `darkball.png` asset, reuse fireball icon for now

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_684761dbad008329b5ef3c29f9de3218