### PR TITLE
Add Warlock corruption debuff

### DIFF
--- a/client/next-js/app/matches/[id]/page.tsx
+++ b/client/next-js/app/matches/[id]/page.tsx
@@ -87,6 +87,7 @@ export default function MatchesPage() {
                             <option value="mage">Mage</option>
                             <option value="warrior">Warrior</option>
                             <option value="archer">Archer</option>
+                            <option value="warlock">Warlock</option>
                         </select>
                     </div>
                     <div className="flex flex-col">

--- a/client/next-js/components/parts/SkillBar.jsx
+++ b/client/next-js/components/parts/SkillBar.jsx
@@ -1,14 +1,27 @@
 import {useEffect, useState} from 'react';
+import {useInterface} from '@/context/inteface';
 import './SkillBar.css';
+import * as mageSkills from '../../skills/mage';
+import * as warlockSkills from '../../skills/warlock';
 
-const SKILLS = [
-    {id: 'fireball', key: 'E', icon: '/icons/fireball.png'},
-    {id: 'iceball', key: 'R', icon: '/icons/spell_frostbolt.jpg'},
-    {id: 'fireblast', key: 'Q', icon: '/icons/spell_fire_fireball.jpg'},
-    {id: 'ice-veins', key: 'F', icon: '/icons/spell_veins.jpg'},
+const DEFAULT_SKILLS = [
+    mageSkills.fireball,
+    mageSkills.iceball,
+    mageSkills.fireblast,
+    mageSkills.iceVeins,
+];
+
+const WARLOCK_SKILLS = [
+    warlockSkills.darkball,
+    warlockSkills.corruption,
+    mageSkills.fireblast,
+    mageSkills.iceVeins,
 ];
 
 export const SkillBar = () => {
+    const {state: {character}} = useInterface();
+    const skills = character?.name === 'warlock' ? WARLOCK_SKILLS : DEFAULT_SKILLS;
+
     const [cooldowns, setCooldowns] = useState({});
 
     useEffect(() => {
@@ -44,7 +57,7 @@ export const SkillBar = () => {
 
     return (
         <div id="skills-bar">
-            {SKILLS.map((skill) => {
+            {skills.map((skill) => {
                 const data = cooldowns[skill.id];
                 let percent = 0;
                 let text = skill.key;

--- a/client/next-js/skills/mage/fireball.js
+++ b/client/next-js/skills/mage/fireball.js
@@ -1,0 +1,14 @@
+export const meta = { id: 'fireball', key: 'E', icon: '/icons/fireball.png' };
+
+export default function castFireball({ playerId, castSpellImpl, igniteHands, castSphere, fireballMesh, sounds }) {
+  igniteHands(playerId, 1000);
+  castSpellImpl(
+    playerId,
+    30,
+    1000,
+    (model) => castSphere(model, fireballMesh.clone(), meta.id),
+    sounds.fireballCast,
+    sounds.fireball,
+    meta.id
+  );
+}

--- a/client/next-js/skills/mage/fireblast.js
+++ b/client/next-js/skills/mage/fireblast.js
@@ -1,0 +1,16 @@
+export const meta = { id: 'fireblast', key: 'Q', icon: '/icons/spell_fire_fireball.jpg' };
+
+export default function castFireblast({ playerId, globalSkillCooldown, isCasting, mana, getTargetPlayer, dispatch, sendToSocket, activateGlobalCooldown, startSkillCooldown, FIREBLAST_DAMAGE }) {
+  if (globalSkillCooldown || isCasting) return;
+  if (mana < 20) {
+    console.log('Not enough mana for fireblast!');
+    return;
+  }
+  const targetId = getTargetPlayer();
+  if (!targetId) {
+    dispatch({ type: 'SEND_CHAT_MESSAGE', payload: `No target for  fireblast!` });
+  }
+  sendToSocket({ type: 'CAST_SPELL', payload: { type: 'fireblast', targetId, damage: FIREBLAST_DAMAGE } });
+  activateGlobalCooldown();
+  startSkillCooldown('fireblast');
+}

--- a/client/next-js/skills/mage/iceVeins.js
+++ b/client/next-js/skills/mage/iceVeins.js
@@ -1,0 +1,5 @@
+export const meta = { id: 'ice-veins', key: 'F', icon: '/icons/spell_veins.jpg' };
+
+export default function castIceVeins({ playerId, activateIceVeins }) {
+  activateIceVeins(playerId);
+}

--- a/client/next-js/skills/mage/iceball.js
+++ b/client/next-js/skills/mage/iceball.js
@@ -1,0 +1,14 @@
+export const meta = { id: 'iceball', key: 'R', icon: '/icons/spell_frostbolt.jpg' };
+
+export default function castIceball({ playerId, castSpellImpl, freezeHands, castSphere, iceballMesh, sounds }) {
+  freezeHands(playerId, 1000);
+  castSpellImpl(
+    playerId,
+    50,
+    1500,
+    (model) => castSphere(model, iceballMesh.clone(), meta.id),
+    sounds.iceballCast,
+    sounds.iceball,
+    meta.id
+  );
+}

--- a/client/next-js/skills/mage/index.js
+++ b/client/next-js/skills/mage/index.js
@@ -1,0 +1,4 @@
+export { meta as fireball } from './fireball';
+export { meta as iceball } from './iceball';
+export { meta as fireblast } from './fireblast';
+export { meta as iceVeins } from './iceVeins';

--- a/client/next-js/skills/warlock/corruption.js
+++ b/client/next-js/skills/warlock/corruption.js
@@ -1,0 +1,16 @@
+export const meta = { id: 'corruption', key: 'R', icon: '/icons/corruption.png' };
+
+export default function castCorruption({ playerId, globalSkillCooldown, isCasting, mana, getTargetPlayer, dispatch, sendToSocket, activateGlobalCooldown, startSkillCooldown }) {
+  if (globalSkillCooldown || isCasting) return;
+  if (mana < 30) {
+    console.log('Not enough mana for corruption!');
+    return;
+  }
+  const targetId = getTargetPlayer();
+  if (!targetId) {
+    dispatch({ type: 'SEND_CHAT_MESSAGE', payload: `No target for corruption!` });
+  }
+  sendToSocket({ type: 'CAST_SPELL', payload: { type: 'corruption', targetId } });
+  activateGlobalCooldown();
+  startSkillCooldown('corruption');
+}

--- a/client/next-js/skills/warlock/darkball.js
+++ b/client/next-js/skills/warlock/darkball.js
@@ -1,0 +1,14 @@
+export const meta = { id: 'darkball', key: 'E', icon: '/icons/fireball.png' };
+
+export default function castDarkball({ playerId, castSpellImpl, igniteHands, castSphere, darkballMesh, sounds }) {
+  igniteHands(playerId, 1000);
+  castSpellImpl(
+    playerId,
+    30,
+    1000,
+    (model) => castSphere(model, darkballMesh.clone(), meta.id),
+    sounds.fireballCast,
+    sounds.fireball,
+    meta.id
+  );
+}

--- a/client/next-js/skills/warlock/index.js
+++ b/client/next-js/skills/warlock/index.js
@@ -1,0 +1,2 @@
+export { meta as darkball } from './darkball';
+export { meta as corruption } from './corruption';

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -4,6 +4,8 @@ const http = require('http');
 const UPDATE_MATCH_INTERVAL = 33;
 const SPELL_COST = {
     'fireball': 25,
+    'darkball': 25,
+    'corruption': 30,
     'iceball': 25,
     'fireblast': 20,
     'shield': 80,
@@ -82,6 +84,7 @@ function createPlayer() {
         animationAction: '',
         rotation: {y: 0},
         buffs: [],
+        debuffs: [],
         kills: 0,
         deaths: 0,
         assists: 0,
@@ -133,6 +136,60 @@ function checkRunePickup(match, playerId) {
     }
 }
 
+function applyDamage(match, victimId, dealerId, damage) {
+    const victim = match.players.get(victimId);
+    if (!victim) return;
+    const attacker = match.players.get(dealerId);
+    let totalDamage = Number(damage);
+    if (attacker && attacker.buffs.length) {
+        const now = Date.now();
+        attacker.buffs.forEach(buff => {
+            if (buff.type === 'damage' && buff.expires > now) {
+                totalDamage += buff.bonus;
+            }
+        });
+    }
+
+    victim.hp = Math.max(0, victim.hp - totalDamage);
+    if (victim.hp <= 0) {
+        victim.deaths++;
+        if (attacker) {
+            attacker.kills++;
+            attacker.points += 100;
+            broadcastToMatch(match.id, {
+                type: 'KILL',
+                killerId: dealerId,
+            });
+            if (attacker.kills >= 15 && !match.finished) {
+                match.finished = true;
+                match.summary = Array.from(match.players.entries()).map(([pid, p]) => ({
+                    id: pid,
+                    kills: p.kills,
+                    deaths: p.deaths,
+                }));
+                finishedMatches.set(match.id, match.summary);
+                broadcastToMatch(match.id, {
+                    type: 'MATCH_FINISHED',
+                    matchId: match.id,
+                });
+            }
+        }
+    }
+
+    broadcastToMatch(match.id, {
+        type: 'UPDATE_STATS',
+        playerId: victimId,
+        hp: victim.hp,
+        mana: victim.mana,
+    });
+
+    broadcastToMatch(match.id, {
+        type: 'DAMAGE',
+        targetId: victimId,
+        amount: totalDamage,
+    });
+}
+
 ws.on('connection', (socket) => {
     console.log('New client connected.');
     const id = Date.now();
@@ -152,12 +209,22 @@ ws.on('connection', (socket) => {
     setInterval(() => {
         const now = Date.now();
         for (const match of matches.values()) {
-            match.players.forEach(player => {
+            match.players.forEach((player, pid) => {
                 if (player.mana < 100) {
                     player.mana = Math.min(100, player.mana + 5);
                 }
                 if (player.buffs.length) {
                     player.buffs = player.buffs.filter(b => b.expires > now);
+                }
+                if (player.debuffs && player.debuffs.length) {
+                    player.debuffs = player.debuffs.filter(deb => {
+                        if (deb.nextTick <= now) {
+                            deb.nextTick = now + deb.interval;
+                            applyDamage(match, pid, deb.casterId, deb.damage);
+                            deb.ticks--;
+                        }
+                        return deb.ticks > 0;
+                    });
                 }
             });
         }
@@ -346,7 +413,7 @@ ws.on('connection', (socket) => {
                             player.hp = Math.min(100, player.hp + 20);
                         }
 
-                        if (['fireball', 'iceball', 'shield', 'ice-veins', 'fireblast'].includes(message.payload.type)) {
+                        if (['fireball', 'darkball', 'corruption', 'iceball', 'shield', 'ice-veins', 'fireblast'].includes(message.payload.type)) {
                             broadcastToMatch(match.id, {
                                 type: 'CAST_SPELL',
                                 payload: message.payload,
@@ -356,6 +423,20 @@ ws.on('connection', (socket) => {
 
                         if (message.payload.type === 'ice-veins') {
                             player.buffs.push({type: 'haste', percent: 0.3, expires: Date.now() + 15000});
+                        }
+                        if (message.payload.type === 'corruption' && message.payload.targetId) {
+                            const target = match.players.get(message.payload.targetId);
+                            if (target) {
+                                target.debuffs = target.debuffs || [];
+                                target.debuffs.push({
+                                    type: 'corruption',
+                                    casterId: id,
+                                    damage: 10,
+                                    interval: 2000,
+                                    nextTick: Date.now() + 2000,
+                                    ticks: 5,
+                                });
+                            }
                         }
 
                         broadcastToMatch(match.id, {
@@ -370,59 +451,7 @@ ws.on('connection', (socket) => {
 
             case 'TAKE_DAMAGE':
                 if (match) {
-                    const victim = match.players.get(id);
-                    if (victim) {
-                        const attacker = match.players.get(message.damageDealerId);
-                        let totalDamage = Number(message.damage);
-                        if (attacker && attacker.buffs.length) {
-                            const now = Date.now();
-                            attacker.buffs.forEach(buff => {
-                                if (buff.type === 'damage' && buff.expires > now) {
-                                    totalDamage += buff.bonus;
-                                }
-                            });
-                        }
-
-                        victim.hp = Math.max(0, victim.hp - totalDamage);
-                        if (victim.hp <= 0) {
-                        victim.deaths++;
-                        const killer = match.players.get(message.damageDealerId);
-                        if (killer) {
-                            killer.kills++;
-                            killer.points += 100;
-                            broadcastToMatch(match.id, {
-                                type: 'KILL',
-                                killerId: message.damageDealerId,
-                            });
-                            if (killer.kills >= 15 && !match.finished) {
-                                    match.finished = true;
-                                    match.summary = Array.from(match.players.entries()).map(([pid, p]) => ({
-                                        id: pid,
-                                        kills: p.kills,
-                                        deaths: p.deaths,
-                                    }));
-                                    finishedMatches.set(match.id, match.summary);
-                                    broadcastToMatch(match.id, {
-                                        type: 'MATCH_FINISHED',
-                                        matchId: match.id,
-                                    });
-                                }
-                            }
-                        }
-
-                        broadcastToMatch(match.id, {
-                            type: 'UPDATE_STATS',
-                            playerId: id,
-                            hp: victim.hp,
-                            mana: victim.mana,
-                        });
-
-                        broadcastToMatch(match.id, {
-                            type: 'DAMAGE',
-                            targetId: id,
-                            amount: totalDamage,
-                        });
-                    }
+                    applyDamage(match, id, message.damageDealerId, message.damage);
                 }
                 break;
 


### PR DESCRIPTION
## Summary
- add warlock corruption spell and cooldown
- display corruption icon in the skill bar
- apply corruption debuff server-side
- send corruption debuff events to affected player
- refactor spells into class folders

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_684761dbad008329b5ef3c29f9de3218