### PR TITLE
Add Immolate prerequisite for Conflagrate

### DIFF
--- a/client/next-js/components/parts/SkillBar.jsx
+++ b/client/next-js/components/parts/SkillBar.jsx
@@ -14,8 +14,8 @@ const DEFAULT_SKILLS = [
 const WARLOCK_SKILLS = [
     warlockSkills.darkball,
     warlockSkills.corruption,
-    mageSkills.fireblast,
-    mageSkills.iceVeins,
+    warlockSkills.immolate,
+    warlockSkills.conflagrate,
 ];
 
 export const SkillBar = () => {

--- a/client/next-js/skills/warlock/conflagrate.js
+++ b/client/next-js/skills/warlock/conflagrate.js
@@ -1,0 +1,35 @@
+export const meta = { id: 'conflagrate', key: 'F', icon: '/icons/spell_fire_fireball.jpg' };
+
+export default function castConflagrate({
+  playerId,
+  globalSkillCooldown,
+  isCasting,
+  mana,
+  getTargetPlayer,
+  dispatch,
+  sendToSocket,
+  activateGlobalCooldown,
+  startSkillCooldown,
+  FIREBLAST_DAMAGE,
+  isTargetBurning,
+}) {
+  if (globalSkillCooldown || isCasting) return;
+  if (mana < 20) {
+    console.log('Not enough mana for conflagrate!');
+    return;
+  }
+  const targetId = getTargetPlayer();
+  if (!targetId) {
+    dispatch({ type: 'SEND_CHAT_MESSAGE', payload: `No target for conflagrate!` });
+    return;
+  }
+
+  if (typeof isTargetBurning === 'function' && !isTargetBurning(targetId)) {
+    dispatch({ type: 'SEND_CHAT_MESSAGE', payload: `Target is not affected by Immolate!` });
+    return;
+  }
+
+  sendToSocket({ type: 'CAST_SPELL', payload: { type: 'conflagrate', targetId, damage: FIREBLAST_DAMAGE } });
+  activateGlobalCooldown();
+  startSkillCooldown('conflagrate');
+}

--- a/client/next-js/skills/warlock/immolate.js
+++ b/client/next-js/skills/warlock/immolate.js
@@ -1,0 +1,16 @@
+export const meta = { id: 'immolate', key: 'Q', icon: '/icons/spell_immolation.jpg' };
+
+export default function castImmolate({ playerId, globalSkillCooldown, isCasting, mana, getTargetPlayer, dispatch, sendToSocket, activateGlobalCooldown, startSkillCooldown }) {
+  if (globalSkillCooldown || isCasting) return;
+  if (mana < 30) {
+    console.log('Not enough mana for immolate!');
+    return;
+  }
+  const targetId = getTargetPlayer();
+  if (!targetId) {
+    dispatch({ type: 'SEND_CHAT_MESSAGE', payload: `No target for immolate!` });
+  }
+  sendToSocket({ type: 'CAST_SPELL', payload: { type: 'immolate', targetId } });
+  activateGlobalCooldown();
+  startSkillCooldown('immolate');
+}

--- a/client/next-js/skills/warlock/index.js
+++ b/client/next-js/skills/warlock/index.js
@@ -1,2 +1,4 @@
 export { meta as darkball } from './darkball';
 export { meta as corruption } from './corruption';
+export { meta as immolate } from './immolate';
+export { meta as conflagrate } from './conflagrate';


### PR DESCRIPTION
## Summary
- require Immolate debuff to cast Conflagrate
- notify client when target lacks Immolate

## Testing
- `npm run --prefix client/next-js lint` *(fails: ESLint couldn't find plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6847cf775f6c83298c7365217ade5a6a