### PR TITLE
Add on-screen damage display for player

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -90,6 +90,7 @@ export function Game({models, sounds, matchId, character}) {
         const hpBar = document.getElementById("hpBar");
         const damageBar = document.getElementById("damage");
         const manaBar = document.getElementById("manaBar");
+        const selfDamage = document.getElementById("selfDamage");
 
         const activeShields = new Map(); // key = playerId
         const activeHandEffects = new Map(); // key = playerId -> { effectKey: {left, right} }
@@ -2149,6 +2150,19 @@ export function Game({models, sounds, matchId, character}) {
             }, 5000);
         }
 
+        function showSelfDamage(amount) {
+            if (!selfDamage) return;
+            const div = document.createElement('div');
+            div.className = 'damage-label';
+            div.textContent = String(amount);
+            selfDamage.appendChild(div);
+            setTimeout(() => {
+                if (div.parentNode) {
+                    div.parentNode.removeChild(div);
+                }
+            }, 1000);
+        }
+
         function castSphereOtherUser(data, ownerId) {
             let material;
             if (data.type === "fireball") {
@@ -2286,6 +2300,7 @@ export function Game({models, sounds, matchId, character}) {
                     if (message.targetId) {
                         showDamage(message.targetId, message.amount);
                         if (message.targetId === myPlayerId) {
+                            showSelfDamage(message.amount);
                             sounds.damage.volume = 0.5;
                             sounds.damage.currentTime = 0;
                             sounds.damage.play();

--- a/client/next-js/components/layout/Interface.css
+++ b/client/next-js/components/layout/Interface.css
@@ -81,3 +81,20 @@
     align-items: center;
     gap: 2px;
 }
+
+#selfDamage {
+    position: absolute;
+    top: 55%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    z-index: 1000;
+}
+
+#selfDamage .damage-label {
+    font-size: 20px;
+}

--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -40,6 +40,8 @@ export const Interface = () => {
                 />
             </div>
 
+            <div id="selfDamage" className="self-damage-container"></div>
+
             <button
                 id="respawnButton"
                 style={{


### PR DESCRIPTION
## Summary
- show damage numbers for your own character
- display self-damage overlay in the interface

## Testing
- `npm test` in `server` (fails: no test specified)
- `npm test` in `client/next-js` (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_68480af443cc8329bf3303d0534f9b6b