### PR TITLE
Reduce DoT damage for warlock

### DIFF
--- a/server/server.cjs
+++ b/server/server.cjs
@@ -448,7 +448,7 @@ ws.on('connection', (socket) => {
                                 target.debuffs.push({
                                     type: 'corruption',
                                     casterId: id,
-                                    damage: 10,
+                                    damage: 7,
                                     interval: 2000,
                                     nextTick: Date.now() + 2000,
                                     ticks: 5,
@@ -462,7 +462,7 @@ ws.on('connection', (socket) => {
                                 target.debuffs.push({
                                     type: 'immolate',
                                     casterId: id,
-                                    damage: 10,
+                                    damage: 7,
                                     interval: 1000,
                                     nextTick: Date.now() + 1000,
                                     ticks: 5,


### PR DESCRIPTION
## Summary
- tune down Corruption and Immolate damage-over-time effects

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68480d4faf148329aa35c5911b40ae67