### PR TITLE
Fix cooldown gating in castSpell

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -859,6 +859,9 @@ export function Game({models, sounds, matchId, character}) {
 
 
         function castSpell(spellType, playerId = myPlayerId) {
+            if (globalSkillCooldown || isCasting || isSkillOnCooldown(spellType)) {
+                return;
+            }
             switch (spellType) {
                 case 'ice-shield':
                     castSpellImpl(
@@ -975,9 +978,6 @@ export function Game({models, sounds, matchId, character}) {
                     });
                     break;
                 case "ice-veins":
-                    if (globalSkillCooldown || isCasting || isSkillOnCooldown('ice-veins')) {
-                        break;
-                    }
                     castIceVeins({
                         playerId,
                         activateIceVeins,

--- a/client/next-js/skills/mage/fireblast.js
+++ b/client/next-js/skills/mage/fireblast.js
@@ -9,6 +9,7 @@ export default function castFireblast({ playerId, globalSkillCooldown, isCasting
   const targetId = getTargetPlayer();
   if (!targetId) {
     dispatch({ type: 'SEND_CHAT_MESSAGE', payload: `No target for  fireblast!` });
+    return;
   }
   sendToSocket({ type: 'CAST_SPELL', payload: { type: 'fireblast', targetId, damage: FIREBLAST_DAMAGE } });
   activateGlobalCooldown();

--- a/client/next-js/skills/warlock/corruption.js
+++ b/client/next-js/skills/warlock/corruption.js
@@ -9,6 +9,7 @@ export default function castCorruption({ playerId, globalSkillCooldown, isCastin
   const targetId = getTargetPlayer();
   if (!targetId) {
     dispatch({ type: 'SEND_CHAT_MESSAGE', payload: `No target for corruption!` });
+    return;
   }
   sendToSocket({ type: 'CAST_SPELL', payload: { type: 'corruption', targetId } });
   activateGlobalCooldown();

--- a/client/next-js/skills/warlock/immolate.js
+++ b/client/next-js/skills/warlock/immolate.js
@@ -9,6 +9,7 @@ export default function castImmolate({ playerId, globalSkillCooldown, isCasting,
   const targetId = getTargetPlayer();
   if (!targetId) {
     dispatch({ type: 'SEND_CHAT_MESSAGE', payload: `No target for immolate!` });
+    return;
   }
   sendToSocket({ type: 'CAST_SPELL', payload: { type: 'immolate', targetId } });
   activateGlobalCooldown();


### PR DESCRIPTION
## Summary
- check global and skill-specific cooldowns once at the start of `castSpell`
- remove per-case cooldown guards

## Testing
- `npm test` in `server` *(fails: Error: no test specified)*
- `npm test` in `client/next-js` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6848145fe3cc8329bfcb8af3961407a6