### PR TITLE
Improve damage label styles

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -2147,7 +2147,7 @@ export function Game({models, sounds, matchId, character}) {
                     player.remove(record.label);
                     damageLabels.delete(playerId);
                 }
-            }, 5000);
+            }, 1000);
         }
 
         function showSelfDamage(amount) {

--- a/client/next-js/components/layout/Interface.css
+++ b/client/next-js/components/layout/Interface.css
@@ -67,12 +67,12 @@
 
 .damage-label {
     color: #fff;
-    background: rgba(255, 0, 0, 0.7);
     padding: 2px 4px;
     border-radius: 3px;
-    font-weight: bold;
-    font-size: 12px;
+    font-weight: 800;
+    font-size: 16px;
     pointer-events: none;
+    animation: floatFade 1s ease-out forwards;
 }
 
 .damage-label-container {
@@ -96,5 +96,16 @@
 }
 
 #selfDamage .damage-label {
-    font-size: 20px;
+    font-size: 24px;
+}
+
+@keyframes floatFade {
+    from {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
 }


### PR DESCRIPTION
## Summary
- restyle damage numbers so they are larger and fade away
- shorten displayed enemy damage duration

## Testing
- `npm run lint` *(fails: cannot find module 'es-abstract/...')*

------
https://chatgpt.com/codex/tasks/task_e_68486a8dacf083299a94b923c89c8ab5