### PR TITLE
Pre-generate chest loot and enforce open timer

### DIFF
--- a/client/next-js/consts/index.ts
+++ b/client/next-js/consts/index.ts
@@ -4,3 +4,4 @@ export const NETWORK = process.env.NEXT_PUBLIC_NETWORK as
   | "testnet"
   | "devnet";
 export const TREASURY_CAP_ID = process.env.NEXT_PUBLIC_TREASURY_CAP_ID;
+export const CLOCK_ID = '0x6';

--- a/client/next-js/hooks/useTransaction.js
+++ b/client/next-js/hooks/useTransaction.js
@@ -1,6 +1,6 @@
 import {Transaction} from "@mysten/sui/transactions";
 import {useCurrentAccount, useSignTransaction, useSuiClient} from "@mysten/dapp-kit";
-import {PACKAGE_ID, TREASURY_CAP_ID} from "@/consts";
+import {PACKAGE_ID, CLOCK_ID} from "@/consts";
 
 export const useTransaction = () => {
     const account = useCurrentAccount();
@@ -58,8 +58,7 @@ export const useTransaction = () => {
                 target: `${PACKAGE_ID}::lootbox::open`,
                 arguments: [
                     tx.object(id),
-                    tx.object(TREASURY_CAP_ID),
-                    tx.pure([], 'vector<u8>'),
+                    tx.object(CLOCK_ID),
                 ],
             });
 

--- a/server/sui.cjs
+++ b/server/sui.cjs
@@ -12,6 +12,7 @@ const client = new SuiClient({
 const PACKAGE_ID = '0x9747359e604b83d72dbaaa05ec39558a390138f656085d7abf6604e1805c3546';
 const TREASURY_CAP_OBJECT_ID = '0xa39d534ad0acc77b4d83f099a556d88ac11745c4d4d395b00d99217d9d22ff13';
 const LOOTBOX_CAP_OBJECT_ID = '0x0123456789abcdef';
+const CLOCK_OBJECT_ID = '0x6';
 
 // Function to send a mint transaction
 async function mintCoins(recipientAddress, amount) {
@@ -57,7 +58,11 @@ async function mintChest(recipientAddress, type) {
         const fn = `create_${type}`;
         const [box] = tx.moveCall({
             target: `${PACKAGE_ID}::lootbox::${fn}`,
-            arguments: [tx.object(LOOTBOX_CAP_OBJECT_ID)],
+            arguments: [
+                tx.object(LOOTBOX_CAP_OBJECT_ID),
+                tx.object(TREASURY_CAP_OBJECT_ID),
+                tx.object(CLOCK_OBJECT_ID),
+            ],
         });
         tx.transferObjects([box], tx.pure.address(recipientAddress));
         tx.setGasBudget(10000000);

--- a/smart-contracts/meta_war/sources/lootbox
+++ b/smart-contracts/meta_war/sources/lootbox
@@ -6,7 +6,8 @@ module meta_war::lootbox {
     use sui::vector;
     use sui::coin;
     use sui::option;
-    use meta_war::coin::{Self as mw_coin, COIN};
+    use sui::clock::{Self as clock, Clock};
+    use meta_war::coin::{COIN};
 
     /// ---------- capability -------------------------------------------------
     public struct LootBoxAdminCap has key { id: UID }
@@ -26,96 +27,131 @@ module meta_war::lootbox {
     public struct EpicToken has key { id: UID }
 
     /// ---------- Loot-box ---------------------------------------------------
-    public struct LootBox has key { id: UID, quality: u8 }
+    public struct LootBox has key {
+        id: UID,
+        quality: u8,
+        coins: coin::Coin<COIN>,
+        staff_foo: option::Option<StaffFoo>,
+        staff_bar: option::Option<StaffBar>,
+        epic: option::Option<EpicToken>,
+        unlock_time: u64,
+    }
 
     const COMMON: u8 = 0;
     const RARE: u8 = 1;
     const EPIC: u8 = 2;
+    const DAY_MS: u64 = 86_400_000;     // 1 day
+    const E_NOT_READY: u64 = 0;
 
     /// чеканить коробку качества common (по умолчанию)
     /// требуются права администратора
     public fun create(
         cap : &mut LootBoxAdminCap,
+        tc  : &mut coin::TreasuryCap<COIN>,
+        clock_ref: &Clock,
         ctx : &mut TxContext
     ): LootBox {
-        create_common(cap, ctx)
+        create_common(cap, tc, clock_ref, ctx)
     }
 
     /// чеканить common коробку
     public fun create_common(
         _cap : &mut LootBoxAdminCap,
+        tc   : &mut coin::TreasuryCap<COIN>,
+        clock_ref: &Clock,
         ctx  : &mut TxContext
     ): LootBox {
-        LootBox { id: object::new(ctx), quality: COMMON }
+        let amount = (random::rand_u64(ctx) % 3) + 1;         // 1..3
+        let coins  = coin::mint(tc, amount, ctx);
+        LootBox {
+            id: object::new(ctx),
+            quality: COMMON,
+            coins,
+            staff_foo: option::none<StaffFoo>(),
+            staff_bar: option::none<StaffBar>(),
+            epic: option::none<EpicToken>(),
+            unlock_time: clock::timestamp_ms(clock_ref) + DAY_MS,
+        }
     }
 
     /// чеканить rare коробку
     public fun create_rare(
         _cap : &mut LootBoxAdminCap,
+        tc   : &mut coin::TreasuryCap<COIN>,
+        clock_ref: &Clock,
         ctx  : &mut TxContext
     ): LootBox {
-        LootBox { id: object::new(ctx), quality: RARE }
+        let amount = (random::rand_u64(ctx) % 6) + 3;         // 3..8
+        let coins  = coin::mint(tc, amount, ctx);
+        let (staff_foo, staff_bar) = maybe_create_staff(ctx);
+        LootBox {
+            id: object::new(ctx),
+            quality: RARE,
+            coins,
+            staff_foo,
+            staff_bar,
+            epic: option::none<EpicToken>(),
+            unlock_time: clock::timestamp_ms(clock_ref) + DAY_MS,
+        }
     }
 
     /// чеканить epic коробку
     public fun create_epic(
         _cap : &mut LootBoxAdminCap,
+        tc   : &mut coin::TreasuryCap<COIN>,
+        clock_ref: &Clock,
         ctx  : &mut TxContext
     ): LootBox {
-        LootBox { id: object::new(ctx), quality: EPIC }
-    }
-
-    /// открыть коробку в зависимости от её качества
-    /// * `lb`     — сама коробка (сжигается)
-    /// * `tc`     — TreasuryCap ваших монет
-    public fun open(
-        lb    : LootBox,
-        tc    : &mut coin::TreasuryCap<COIN>,
-        _owned: vector<u8>,
-        ctx   : &mut TxContext,
-    ) {
-        if (lb.quality == COMMON) {
-            open_common(lb, tc, ctx)
-        } else if (lb.quality == RARE) {
-            open_rare(lb, tc, ctx)
-        } else {
-            open_epic(lb, tc, ctx)
+        let amount = (random::rand_u64(ctx) % 3) + 8;         // 8..10
+        let coins  = coin::mint(tc, amount, ctx);
+        let (staff_foo, staff_bar) = maybe_create_staff(ctx);
+        let et = EpicToken { id: object::new(ctx) };
+        LootBox {
+            id: object::new(ctx),
+            quality: EPIC,
+            coins,
+            staff_foo,
+            staff_bar,
+            epic: option::some(et),
+            unlock_time: clock::timestamp_ms(clock_ref) + DAY_MS,
         }
     }
 
-    fun open_common(lb: LootBox, tc: &mut coin::TreasuryCap<COIN>, ctx: &mut TxContext) {
-        let amount = (random::rand_u64(ctx) % 3) + 1;         // 1..3
-        let coins  = coin::mint(tc, amount, ctx);
+    /// открыть коробку если истек таймер
+    public fun open(
+        lb    : LootBox,
+        clock_ref: &Clock,
+        ctx   : &mut TxContext,
+    ) {
+        assert!(clock::timestamp_ms(clock_ref) >= lb.unlock_time, E_NOT_READY);
+
+        let LootBox {
+            id,
+            quality: _,
+            coins,
+            staff_foo,
+            staff_bar,
+            epic,
+            unlock_time: _,
+        } = lb;
+
         transfer::public_transfer(coins, tx_context::sender(ctx));
-        object::delete_object(lb);
+        option::do(staff_foo, |foo| transfer::public_transfer(foo, tx_context::sender(ctx)));
+        option::do(staff_bar, |bar| transfer::public_transfer(bar, tx_context::sender(ctx)));
+        option::do(epic, |et| transfer::public_transfer(et, tx_context::sender(ctx)));
+        object::delete(id);
     }
 
-    fun open_rare(lb: LootBox, tc: &mut coin::TreasuryCap<COIN>, ctx: &mut TxContext) {
-        let amount = (random::rand_u64(ctx) % 6) + 3;         // 3..8
-        let coins  = coin::mint(tc, amount, ctx);
-        transfer::public_transfer(coins, tx_context::sender(ctx));
-        maybe_mint_staff(ctx);
-        object::delete_object(lb);
-    }
-
-    fun open_epic(lb: LootBox, tc: &mut coin::TreasuryCap<COIN>, ctx: &mut TxContext) {
-        let amount = (random::rand_u64(ctx) % 3) + 8;         // 8..10
-        let coins  = coin::mint(tc, amount, ctx);
-        transfer::public_transfer(coins, tx_context::sender(ctx));
-        maybe_mint_staff(ctx);
-        let et = EpicToken { id: object::new(ctx) };
-        transfer::public_transfer(et, tx_context::sender(ctx));
-        object::delete_object(lb);
-    }
-
-    fun maybe_mint_staff(ctx: &mut TxContext) {
+    fun maybe_create_staff(ctx: &mut TxContext): (option::Option<StaffFoo>, option::Option<StaffBar>) {
         let r = random::rand_u64(ctx) % 100;
         if (r < 5) {
             let foo = StaffFoo { id: object::new(ctx) };
-            transfer::public_transfer(foo, tx_context::sender(ctx));
+            (option::some(foo), option::none<StaffBar>())
         } else if (r < 10) {
             let bar = StaffBar { id: object::new(ctx) };
-            transfer::public_transfer(bar, tx_context::sender(ctx));
+            (option::none<StaffFoo>(), option::some(bar))
+        } else {
+            (option::none<StaffFoo>(), option::none<StaffBar>())
         }
     }
 }


### PR DESCRIPTION
## Summary
- generate lootbox rewards when minted
- add opening delay using the global clock
- adjust JavaScript helper scripts for new Move function signatures
- open lootboxes without passing TreasuryCap

## Testing
- `npm test` *(fails: no tests defined)*
- `sui move test --filter none` *(fails: `sui` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684876a17bb483298a8be69111c3caa8