### PR TITLE
Improve ice-veins buff

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -1088,9 +1088,9 @@ export function Game({models, sounds, matchId, character}) {
             const {mixer, actions} = players.get(myPlayerId)
 
             const buffs = players.get(playerId)?.buffs || [];
-            const haste = buffs.find(b => b.type === 'haste');
-            if (haste) {
-                duration = duration * (1 - (haste.percent || 0.3));
+            const iceVeins = buffs.find(b => b.type === 'ice-veins');
+            if (iceVeins) {
+                duration = duration * (1 - (iceVeins.percent || 0.4));
             }
 
             const onCastEnd = () => {

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -442,7 +442,12 @@ ws.on('connection', (socket) => {
                         }
 
                         if (message.payload.type === 'ice-veins') {
-                            player.buffs.push({type: 'haste', percent: 0.3, expires: Date.now() + 15000});
+                            player.buffs.push({
+                                type: 'ice-veins',
+                                percent: 0.4,
+                                expires: Date.now() + 15000,
+                                icon: '/icons/spell_veins.jpg',
+                            });
                         }
                         if (message.payload.type === 'corruption' && message.payload.targetId) {
                             const target = match.players.get(message.payload.targetId);


### PR DESCRIPTION
## Summary
- update server buff type for ice-veins and increase cast-speed bonus to 40%
- adjust client spell casting to read the new buff name

## Testing
- `npm test` in `server`
- `npm test` in `client/next-js` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848828f7f108329953bbcf0790767c5