### PR TITLE
Add debuff icons

### DIFF
--- a/server/server.cjs
+++ b/server/server.cjs
@@ -460,6 +460,7 @@ ws.on('connection', (socket) => {
                                     interval: 2000,
                                     nextTick: Date.now() + 2000,
                                     ticks: 5,
+                                    icon: '/icons/spell_corruption.jpg',
                                 });
                             }
                         }
@@ -474,6 +475,7 @@ ws.on('connection', (socket) => {
                                     interval: 1000,
                                     nextTick: Date.now() + 1000,
                                     ticks: 5,
+                                    icon: '/icons/spell_immolation.jpg',
                                 });
                             }
                         }


### PR DESCRIPTION
## Summary
- show proper icons for corruption and immolate debuffs

## Testing
- `npm run lint` *(fails: 13 warnings, but no errors)*
- `npm test` in `server` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68496dc21fac8329a586cc67f8c8cdd7