### PR TITLE
Add user profile module in Move with tests

### DIFF
--- a/smart-contracts/meta_war/sources/profile.move
+++ b/smart-contracts/meta_war/sources/profile.move
@@ -1,0 +1,27 @@
+module meta_war::profile {
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
+
+    /// Player profile
+    public struct Profile has key {
+        id: UID,
+        nickname: vector<u8>,
+        rank: u64,
+    }
+
+    /// Create new profile with nickname and zero rank
+    public fun create(nickname: vector<u8>, ctx: &mut TxContext): Profile {
+        Profile { id: object::new(ctx), nickname, rank: 0 }
+    }
+
+    /// Update nickname
+    public fun set_nickname(profile: &mut Profile, nickname: vector<u8>) {
+        profile.nickname = nickname
+    }
+
+    /// Add rank points
+    public fun add_rank(profile: &mut Profile, points: u64) {
+        profile.rank = profile.rank + points
+    }
+}

--- a/smart-contracts/meta_war/sources/staking.move
+++ b/smart-contracts/meta_war/sources/staking.move
@@ -1,0 +1,31 @@
+module meta_war::staking {
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
+    use sui::coin;
+
+    use meta_war::coin::{COIN};
+
+    /// Error when a non-owner attempts to unstake
+    const ENotOwner: u64 = 0;
+
+    /// Object that holds staked coins
+    public struct Stake has key {
+        id: UID,
+        owner: address,
+        coins: coin::Coin<COIN>,
+    }
+
+    /// Stake coins by locking them in a `Stake` object
+    public fun stake(coins: coin::Coin<COIN>, ctx: &mut TxContext): Stake {
+        Stake { id: object::new(ctx), owner: tx_context::sender(ctx), coins }
+    }
+
+    /// Unstake previously staked coins
+    public fun unstake(stake: Stake, ctx: &mut TxContext) {
+        let Stake { id, owner, coins } = stake;
+        assert!(owner == tx_context::sender(ctx), ENotOwner);
+        transfer::public_transfer(coins, owner);
+        object::delete(id);
+    }
+}

--- a/smart-contracts/meta_war/tests/profile_tests
+++ b/smart-contracts/meta_war/tests/profile_tests
@@ -1,0 +1,31 @@
+module meta_war::profile_test {
+    use sui::test::{Self, TestContext};
+    use sui::vector;
+    use sui::object;
+
+    use meta_war::profile;
+
+    #[test_only]
+    public fun test_create(ctx: &mut TestContext) {
+        let prof = profile::create(b"bob", ctx);
+        assert!(prof.rank == 0, 0);
+        assert!(vector::length(&prof.nickname) == 3, 1);
+        object::delete_object(prof);
+    }
+
+    #[test_only]
+    public fun test_add_rank(ctx: &mut TestContext) {
+        let mut prof = profile::create(b"alice", ctx);
+        profile::add_rank(&mut prof, 5);
+        assert!(prof.rank == 5, 0);
+        object::delete_object(prof);
+    }
+
+    #[test_only]
+    public fun test_set_nickname(ctx: &mut TestContext) {
+        let mut prof = profile::create(b"nick", ctx);
+        profile::set_nickname(&mut prof, b"neo");
+        assert!(vector::length(&prof.nickname) == 3, 0);
+        object::delete_object(prof);
+    }
+}

--- a/smart-contracts/meta_war/tests/staking_tests
+++ b/smart-contracts/meta_war/tests/staking_tests
@@ -1,0 +1,38 @@
+module meta_war::staking_test {
+    use sui::test::{Self, TestContext};
+    use sui::coin;
+    use sui::vector;
+
+    use meta_war::coin::{Self as mw_coin, COIN};
+    use meta_war::staking;
+
+    /* helper: получить treas-cap */
+    fun cap(ctx: &mut TestContext): &mut coin::TreasuryCap<COIN>
+            acquires coin::TreasuryCap {
+        borrow_global_mut<coin::TreasuryCap<COIN>>(TestContext::sender(ctx))
+    }
+
+    /* helper: баланс COIN */
+    fun bal(ctx: &mut TestContext): u64 acquires coin::Coin {
+        let addr = TestContext::sender(ctx);
+        let coins = test::coins_owned_by<COIN>(ctx, addr);
+        let mut sum = 0;
+        let i = 0;
+        while (i < vector::length(&coins)) {
+            sum = sum + coin::value(&vector::borrow(&coins, i));
+            i = i + 1
+        }; sum
+    }
+
+    #[test_only]
+    public fun test_stake_unstake(ctx: &mut TestContext)
+            acquires coin::TreasuryCap, coin::Coin {
+        mw_coin::init(mw_coin::COIN{}, ctx);
+        let start = bal(ctx);
+        let c = coin::mint(cap(ctx), 10, ctx);
+        let stake = staking::stake(c, ctx);
+        assert!(bal(ctx) == start, 0);
+        staking::unstake(stake, ctx);
+        assert!(bal(ctx) == start + 10, 1);
+    }
+}


### PR DESCRIPTION
## Summary
- add a Profile module for user nickname and rank
- include Move tests covering create, nickname update and rank addition
- add staking module for Meta War coin with tests

## Testing
- `apt-get update`
- `sui move test -N 1` *(fails: `sui: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68497abc28a4832983b8641c46c447bc