### PR TITLE
Add NFT rating page

### DIFF
--- a/client/next-js/app/rating/page.tsx
+++ b/client/next-js/app/rating/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import {
+  Card,
+  Table,
+  TableHeader,
+  TableColumn,
+  TableBody,
+  TableRow,
+  TableCell,
+} from "@heroui/react";
+
+import { Navbar } from "@/components/navbar";
+import { title } from "@/components/primitives";
+import { useRatings } from "@/hooks/useRatings";
+
+export default function RatingPage() {
+  const { ratings } = useRatings();
+
+  return (
+    <div className="h-full">
+      <Navbar />
+      <div className="w-full h-full flex justify-center items-start p-4 overflow-y-auto">
+        <Card className="w-full max-w-3xl p-6 space-y-6">
+          <h1 className={title()}>Top NFT Ratings</h1>
+          <Table aria-label="NFT rating table">
+            <TableHeader>
+              <TableColumn>Rank</TableColumn>
+              <TableColumn>Name</TableColumn>
+              <TableColumn>Points</TableColumn>
+            </TableHeader>
+            <TableBody>
+              {ratings.map((r, idx) => (
+                <TableRow key={r.name}>
+                  <TableCell>{idx + 1}</TableCell>
+                  <TableCell>{r.name}</TableCell>
+                  <TableCell>{r.points}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/client/next-js/config/site.ts
+++ b/client/next-js/config/site.ts
@@ -17,6 +17,10 @@ export const siteConfig = {
       label: "Tokenomics",
       href: "/tokenomics",
     },
+    {
+      label: "Rating",
+      href: "/rating",
+    },
     // {
     //   label: "Pricing",
     //   href: "/pricing",
@@ -34,6 +38,10 @@ export const siteConfig = {
     {
       label: "Profile",
       href: "/profile",
+    },
+    {
+      label: "Rating",
+      href: "/rating",
     },
     {
       label: "Dashboard",

--- a/client/next-js/hooks/index.js
+++ b/client/next-js/hooks/index.js
@@ -2,3 +2,4 @@ export * from "./useTransaction";
 export * from "./useCoins";
 export * from "./useLootBoxes";
 export * from "./useSkins";
+export * from "./useRatings";

--- a/client/next-js/hooks/useRatings.ts
+++ b/client/next-js/hooks/useRatings.ts
@@ -1,0 +1,21 @@
+export interface RatingItem {
+  name: string;
+  points: number;
+}
+
+export const useRatings = () => {
+  const ratings: RatingItem[] = [
+    { name: "NFT #1", points: 1500 },
+    { name: "NFT #2", points: 1400 },
+    { name: "NFT #3", points: 1300 },
+    { name: "NFT #4", points: 1200 },
+    { name: "NFT #5", points: 1100 },
+    { name: "NFT #6", points: 1000 },
+    { name: "NFT #7", points: 900 },
+    { name: "NFT #8", points: 800 },
+    { name: "NFT #9", points: 700 },
+    { name: "NFT #10", points: 600 },
+  ];
+
+  return { ratings };
+};


### PR DESCRIPTION
## Summary
- add static rating data hook
- expose new hook from hooks index
- add Rating page listing top NFT points
- link Rating page in navigation

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684aaa96dc4083299fe764c422671823