### PR TITLE
Implement cooldown sound and static overlay

### DIFF
--- a/client/next-js/app/matches/[id]/game/page.tsx
+++ b/client/next-js/app/matches/[id]/game/page.tsx
@@ -77,6 +77,7 @@ export default function GamePage() {
             damage: new Audio('/sounds/damage.ogg'),
             noMana: new Audio('/sounds/no-mana.ogg'),
             noTarget: new Audio('/sounds/no-target.ogg'),
+            cooldown: new Audio('/sounds/coldown.ogg'),
         }
         preloadModels(models)
             .then((loadedModels) => {

--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -962,7 +962,16 @@ export function Game({models, sounds, matchId, character}) {
                 return;
             }
 
-            if (globalSkillCooldown || isCasting || isSkillOnCooldown(spellType)) {
+            if (isSkillOnCooldown(spellType)) {
+                if (sounds?.cooldown) {
+                    sounds.cooldown.currentTime = 0;
+                    sounds.cooldown.volume = 0.5;
+                    sounds.cooldown.play();
+                }
+                return;
+            }
+
+            if (globalSkillCooldown || isCasting) {
                 return;
             }
             switch (spellType) {

--- a/client/next-js/components/parts/SkillBar.css
+++ b/client/next-js/components/parts/SkillBar.css
@@ -40,6 +40,7 @@
     bottom: 0;
     left: 0;
     width: 100%;
+    height: 100%;
     background: rgba(0, 0, 0, 0.6);
     color: white;
     display: flex;

--- a/client/next-js/components/parts/SkillBar.jsx
+++ b/client/next-js/components/parts/SkillBar.jsx
@@ -59,21 +59,16 @@ export const SkillBar = () => {
         <div id="skills-bar">
             {skills.map((skill) => {
                 const data = cooldowns[skill.id];
-                let percent = 0;
                 let text = skill.key;
                 if (data) {
                     const remaining = data.end - Date.now();
-                    percent = remaining / data.duration;
                     text = Math.ceil(remaining / 1000);
                 }
                 return (
                     <div className="skill-button" key={skill.id}>
                         <div className="skill-icon" style={{backgroundImage: `url('${skill.icon}')`}}></div>
                         {data && (
-                            <div
-                                className="cooldown-overlay"
-                                style={{height: `${Math.max(0, percent) * 100}%`}}
-                            >
+                            <div className="cooldown-overlay">
                                 {text}
                             </div>
                         )}


### PR DESCRIPTION
## Summary
- make the cooldown overlay full size with no height animation
- load `coldown.ogg` sound
- play cooldown sound when trying to use a skill on cooldown

## Testing
- `npm run lint`
- `npx -y eslint@8 -c client/next-js/.eslintrc.json client/next-js/components/parts/SkillBar.jsx client/next-js/components/game.jsx client/next-js/app/matches/[id]/game/page.tsx --ext .ts,.tsx,.js,.jsx`

------
https://chatgpt.com/codex/tasks/task_e_684aad0c91c88329ae4a391d953b1b3f