### PR TITLE
Use fireball shader for immolation

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -1836,7 +1836,10 @@ export function Game({models, sounds, matchId, character}) {
             const player = players.get(playerId)?.model;
             if (!player) return;
 
-            const effect = SkeletonUtils.clone(models["fire"]);
+            const effect = new THREE.Mesh(
+                fireballGeometry,
+                fireballMaterial.clone()
+            );
             effect.scale.set(0.5, 0.5, 0.5);
             scene.add(effect);
             activeImmolation.set(playerId, effect);


### PR DESCRIPTION
## Summary
- use fireball material instead of fire model for warlock's immolate effect

## Testing
- `npx eslint . --ext .ts,.tsx`

------
https://chatgpt.com/codex/tasks/task_e_684aad29706c832988fcd9b0f7f3b7bc