### PR TITLE
Add profile creation page

### DIFF
--- a/client/next-js/app/matches/page.tsx
+++ b/client/next-js/app/matches/page.tsx
@@ -14,6 +14,7 @@ import {
 import {Input} from "@heroui/input";
 import {useRouter} from "next/navigation";
 import {Navbar} from "@/components/navbar";
+import {ProfileForm} from "@/components/profile-form";
 
 
 interface Match {
@@ -78,6 +79,7 @@ export default function MatchesPage() {
 
             <div className="flex justify-center items-center">
                <div className="max-w-[640px] min-w-[480px] flex gap-8 flex-col">
+                   <ProfileForm />
                    <Button size='lg' onPress={onOpen}>Create Match</Button>
                    <Button size='lg' color="primary" onPress={fetchMatches}>Fetch Matches</Button>
                    <Table aria-label="Example static collection table">

--- a/client/next-js/app/profile/page.tsx
+++ b/client/next-js/app/profile/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import {Card} from "@heroui/react";
+import {Navbar} from "@/components/navbar";
+import {title} from "@/components/primitives";
+import {ProfileForm} from "@/components/profile-form";
+
+export default function ProfilePage() {
+    return (
+        <div className="h-full">
+            <Navbar/>
+            <div className="w-full h-full flex justify-center items-start p-4 overflow-y-auto">
+                <Card className="w-full max-w-xl p-6 space-y-6">
+                    <h1 className={title()}>Create Profile</h1>
+                    <ProfileForm/>
+                </Card>
+            </div>
+        </div>
+    );
+}
+

--- a/client/next-js/components/profile-form.tsx
+++ b/client/next-js/components/profile-form.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import {useState} from "react";
+import {Input} from "@heroui/input";
+import {Button} from "@heroui/react";
+import {useTransaction} from "@/hooks";
+
+export function ProfileForm() {
+    const [nickname, setNickname] = useState("");
+    const {createProfile} = useTransaction();
+
+    const handleCreate = async () => {
+        if (!nickname) return;
+        try {
+            await createProfile(nickname);
+            setNickname("");
+        } catch (e) {
+            console.error(e);
+        }
+    };
+
+    return (
+        <div className="flex gap-2 items-end">
+            <Input
+                label="Nickname"
+                value={nickname}
+                onValueChange={setNickname}
+            />
+            <Button color="primary" onPress={handleCreate} isDisabled={!nickname}>
+                Create Profile
+            </Button>
+        </div>
+    );
+}
+

--- a/client/next-js/hooks/useTransaction.js
+++ b/client/next-js/hooks/useTransaction.js
@@ -64,6 +64,19 @@ export const useTransaction = () => {
             tx.setSender(account?.address);
 
             return execTransaction(tx);
+        },
+        createProfile(nickname) {
+            const tx = new Transaction();
+
+            const [profile] = tx.moveCall({
+                target: `${PACKAGE_ID}::profile::create`,
+                arguments: [tx.pure.string(nickname)],
+            });
+
+            tx.transferObjects([profile], tx.pure.address(account?.address));
+            tx.setSender(account?.address);
+
+            return execTransaction(tx);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add function to create profile on-chain
- add ProfileForm component
- add profile creation page and show form on matches page

## Testing
- `npm run lint` *(fails: eslint plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ab65855348329b2ce8bb0d73d37e5