### PR TITLE
Add staff models to character

### DIFF
--- a/client/next-js/app/matches/[id]/game/page.tsx
+++ b/client/next-js/app/matches/[id]/game/page.tsx
@@ -38,6 +38,8 @@ export default function GamePage() {
         {id: 'damage_rune', path: 'damage_rune.glb'},
         {id: 'heal_rune', path: 'heal_rune.glb'},
         {id: 'mana_rune', path: 'mana_rune.glb'},
+        {id: 'mage_staff', path: 'skins/items/mage-staff.glb'},
+        {id: 'warlock_staff', path: 'skins/items/warlock-staff.glb'},
     ];
 
     useLayoutEffect(() => {

--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -2093,15 +2093,24 @@ export function Game({models, sounds, matchId, character}) {
         }
 
         function createStaffMesh() {
+            const staffId = character?.name === 'warlock' ? 'warlock_staff' : 'mage_staff';
+            const base = models[staffId];
+            if (base) {
+                const staff = SkeletonUtils.clone(base);
+                staff.scale.set(0.4, 0.4, 0.4);
+                staff.rotation.z = Math.PI / 2;
+                staff.position.set(0, 0.9, -0.2);
+                return staff;
+            }
             const group = new THREE.Group();
             const stick = new THREE.Mesh(
                 new THREE.CylinderGeometry(0.05, 0.05, 1.5, 8),
-                new THREE.MeshStandardMaterial({color: 0x8B4513})
+                new THREE.MeshStandardMaterial({ color: 0x8B4513 })
             );
             stick.position.y = 0.75;
             const top = new THREE.Mesh(
                 new THREE.SphereGeometry(0.1, 16, 16),
-                new THREE.MeshStandardMaterial({color: 0xffffff})
+                new THREE.MeshStandardMaterial({ color: 0xffffff })
             );
             top.position.y = 1.5;
             group.add(stick);


### PR DESCRIPTION
## Summary
- load mage and warlock staff models in game page
- attach the appropriate staff model to a player's spine

## Testing
- `npx eslint@8 -c .eslintrc.json app/matches/[id]/game/page.tsx components/game.jsx`
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_684ac1539e1c8329bcc962034d4bdfdd