### PR TITLE
Add global chat on homepage

### DIFF
--- a/client/next-js/app/matches/[id]/page.tsx
+++ b/client/next-js/app/matches/[id]/page.tsx
@@ -7,7 +7,6 @@ import Image from "next/image";
 import {Button, Table, TableHeader, TableColumn, TableBody, TableRow, TableCell} from "@heroui/react";
 import {useParams, useRouter} from "next/navigation";
 import {Navbar} from "@/components/navbar";
-import {Chat} from "@/components/parts/Chat";
 import {useInterface} from "@/context/inteface";
 
 
@@ -121,8 +120,6 @@ export default function MatchesPage() {
                         </div>
                     )}
 
-
-                <Chat/>
             </div>
         </div>
     );

--- a/client/next-js/app/page.tsx
+++ b/client/next-js/app/page.tsx
@@ -5,6 +5,7 @@ import React from "react";
 
 import General from "@/components/general";
 import {Navbar} from "@/components/navbar";
+import { Chat } from "@/components/parts/Chat";
 
 export default function Home() {
   return (
@@ -23,6 +24,7 @@ export default function Home() {
             <main className="z-[1] flex justify-center w-full h-full overflow-y-auto">
                 <General />
             </main>
+            <Chat />
         </div>
 
       {/*<Card className="max-w-100">*/}

--- a/client/next-js/components/parts/Chat.css
+++ b/client/next-js/components/parts/Chat.css
@@ -6,9 +6,9 @@
     background-color: rgba(0, 0, 0, 0.7);
     border: 2px solid #222;
     border-radius: 5px;
-    position: absolute;
-    bottom: 120px; /* Place above the cast bar */
-    left: 20px; /* Align it to the left */
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
     padding: 10px;
     display: flex;
     flex-direction: column; /* Show the latest messages at the bottom */


### PR DESCRIPTION
## Summary
- add Chat component on the homepage using websocket
- remove lobby chat usage
- position the chat window fixed at bottom-right

## Testing
- `npx eslint -c .eslintrc.json app/page.tsx app/matches/[id]/page.tsx --fix`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ac46e5dbc8329aa992feb3fb943cb