### PR TITLE
Fix staff orientation behind character

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -2105,8 +2105,8 @@ export function Game({models, sounds, matchId, character}) {
             if (base) {
                 const staff = SkeletonUtils.clone(base);
                 staff.scale.set(0.4, 0.4, 0.4);
-                // Rotate the staff so it stands vertically behind the back
-                staff.rotation.set(Math.PI / 2, 0, 0);
+                // Ensure the staff points upward and sits behind the character
+                staff.rotation.set(0, 0, 0);
                 staff.position.set(0, 0.9, -0.2);
                 return staff;
             }
@@ -2123,8 +2123,8 @@ export function Game({models, sounds, matchId, character}) {
             top.position.y = 1.5;
             group.add(stick);
             group.add(top);
-            // Rotate placeholder staff vertically as well
-            group.rotation.set(Math.PI / 2, 0, 0);
+            // Placeholder staff positioned upright
+            group.rotation.set(0, 0, 0);
             group.position.set(0, 0.9, -0.2);
             return group;
         }


### PR DESCRIPTION
## Summary
- fix staff orientation and position behind character

## Testing
- `npm --prefix client/next-js run lint`

------
https://chatgpt.com/codex/tasks/task_e_684b0eb25244832981b2c1f815a07ead