### PR TITLE
Fix build error in lobby page

### DIFF
--- a/client/next-js/app/matches/[id]/page.tsx
+++ b/client/next-js/app/matches/[id]/page.tsx
@@ -38,12 +38,12 @@ export default function MatchesPage() {
                 case 'GET_MATCH':
                     if (message.match) {
                         setMatch(message.match);
-                        setPlayers(Array.from(message.match.players).map(([id]) => Number(id)));
+                        setPlayers((message.match.players as Array<[string, unknown]>).map(([id]) => Number(id)));
                     }
                     break;
                 case 'MATCH_JOINED':
                     if (message.players) {
-                        setPlayers(Array.from(message.players).map(([id]) => Number(id)));
+                        setPlayers((message.players as Array<[string, unknown]>).map(([id]) => Number(id)));
                     }
                     break;
                 case 'PLAYER_LEFT':


### PR DESCRIPTION
## Summary
- fix type casting when parsing match player arrays

## Testing
- `npx next --version` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b30355b748329a367dc82e700fca1