### PR TITLE
Add timer display for buffs

### DIFF
--- a/client/next-js/components/parts/Buffs.css
+++ b/client/next-js/components/parts/Buffs.css
@@ -11,6 +11,7 @@
 }
 
 .buff-icon {
+    position: relative;
     width: 32px;
     height: 32px;
     background: rgba(0,0,0,0.6);
@@ -24,4 +25,15 @@
 .buff-icon img {
     width: 28px;
     height: 28px;
+}
+
+.buff-icon span {
+    position: absolute;
+    bottom: -12px;
+    left: 0;
+    width: 100%;
+    font-size: 10px;
+    color: #fff;
+    text-align: center;
+    pointer-events: none;
 }

--- a/client/next-js/components/parts/Buffs.jsx
+++ b/client/next-js/components/parts/Buffs.jsx
@@ -1,16 +1,47 @@
 import {useInterface} from '@/context/inteface';
+import {useEffect, useState} from 'react';
 import './Buffs.css';
 
 export const Buffs = () => {
     const {state: {buffs = [], debuffs = []}} = useInterface();
+    const [now, setNow] = useState(Date.now());
+
+    useEffect(() => {
+        const id = setInterval(() => setNow(Date.now()), 1000);
+        return () => clearInterval(id);
+    }, []);
 
     if (!buffs.length && !debuffs.length) return null;
 
-    const renderIcon = (item, idx, type) => (
-        <div key={`${type}-${idx}`} className="buff-icon">
-            <img src={item.icon || '/icons/shield.png'} alt={item.type} />
-        </div>
-    );
+    const formatTime = (ms) => {
+        const total = Math.max(0, Math.ceil(ms / 1000));
+        const minutes = Math.floor(total / 60);
+        const seconds = total % 60;
+        if (minutes > 0) {
+            return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+        }
+        return `${seconds}`;
+    };
+
+    const getRemaining = (item) => {
+        if (item.expires) {
+            return item.expires - now;
+        }
+        if (item.ticks && item.interval && item.nextTick) {
+            return (item.ticks - 1) * item.interval + (item.nextTick - now);
+        }
+        return 0;
+    };
+
+    const renderIcon = (item, idx, type) => {
+        const timeLeft = getRemaining(item);
+        return (
+            <div key={`${type}-${idx}`} className="buff-icon">
+                <img src={item.icon || '/icons/shield.png'} alt={item.type} />
+                <span>{formatTime(timeLeft)}</span>
+            </div>
+        );
+    };
 
     return (
         <div className="buffs-container">


### PR DESCRIPTION
## Summary
- show countdown timers for buff and debuff icons
- style timers beneath icons

## Testing
- `npm run lint`
- `npm run build` *(fails: Type error in page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_684bf58cf87c8329a6b608bbf09e6311