### PR TITLE
Replace ice veins texture with glb model

### DIFF
--- a/client/next-js/app/matches/[id]/game/page.tsx
+++ b/client/next-js/app/matches/[id]/game/page.tsx
@@ -46,6 +46,7 @@ export default function GamePage() {
         {id: 'mana_rune', path: 'mana_rune.glb'},
         {id: 'mage_staff', path: 'skins/items/mage-staff.glb'},
         {id: 'warlock_staff', path: 'skins/items/warlock-staff.glb'},
+        {id: 'ice-veins', path: 'ice-veins.glb'},
     ];
 
     useLayoutEffect(() => {

--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -1815,36 +1815,22 @@ export function Game({models, sounds, matchId, character}) {
             const player = players.get(playerId)?.model;
             if (!player) return;
 
-            const group = new THREE.Group();
-            const tex = new THREE.TextureLoader().load('/textures/ice.jpg');
-            tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+            const base = models['ice-veins'];
+            if (!base) return;
 
-            const material = new THREE.SpriteMaterial({
-                map: tex,
-                color: 0xffffff,
-                transparent: true,
-                opacity: 0.75,
+            const effect = SkeletonUtils.clone(base);
+            effect.scale.set(0.5, 0.5, 0.5);
+            effect.traverse((child) => {
+                if (child.isMesh) {
+                    child.material = child.material.clone();
+                }
             });
 
-            const layers = 2;
-            const spritesPerLayer = 3;
-            for (let layer = 0; layer < layers; layer++) {
-                const height = 0.8 + layer * 0.4;
-                for (let i = 0; i < spritesPerLayer; i++) {
-                    const sprite = new THREE.Sprite(material.clone());
-                    sprite.scale.set(1.2, 1.2, 1.2);
-                    const angle = (i / spritesPerLayer) * Math.PI * 2;
-                    sprite.position.set(Math.cos(angle) * 0.8, height, Math.sin(angle) * 0.8);
-                    group.add(sprite);
-                }
-            }
-
-            group.rotation.x = Math.PI / 2;
-            player.add(group);
-            activeIceVeins.set(playerId, group);
+            player.add(effect);
+            activeIceVeins.set(playerId, effect);
 
             setTimeout(() => {
-                group.parent?.remove(group);
+                effect.parent?.remove(effect);
                 activeIceVeins.delete(playerId);
             }, duration);
         }


### PR DESCRIPTION
## Summary
- load new `ice-veins.glb` model in the game page
- render the `ice-veins` buff using the loaded model instead of sprites

## Testing
- `npm run lint` *(fails: eslint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684bf690db8483299b8cdc23e3d69359