### PR TITLE
Add fireball mesh with light and burn effect

### DIFF
--- a/client/next-js/app/matches/[id]/game/page.tsx
+++ b/client/next-js/app/matches/[id]/game/page.tsx
@@ -36,7 +36,6 @@ export default function GamePage() {
 
     const models = [
         {id: 'zone', path: 'zone3.glb'},
-        {id: 'fireball', path: 'fireball.glb'},
         {id: 'character', path: 'skins/vampir.glb'},
         {id: 'heal-effect', path: 'heal-effect.glb'},
         {id: 'fire', path: 'stuff/fire.glb'},


### PR DESCRIPTION
## Summary
- restore generated fireball mesh instead of glb
- attach point light to projectiles
- apply burning effect when player is hit
- remove unused fireball model preload

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c0bf7ce1c8329adcb3016f151f858