### PR TITLE
Fix build error in matches page

### DIFF
--- a/client/next-js/app/matches/[id]/page.tsx
+++ b/client/next-js/app/matches/[id]/page.tsx
@@ -20,7 +20,7 @@ export default function MatchesPage() {
     const params = useParams();
     const router = useRouter();
     const {socket, sendToSocket} = useWS(params?.id);
-    const {dispatch} = useInterface();
+    const {dispatch} = useInterface() as any;
 
     const [match, setMatch] = useState<Match | null>(null);
     const [players, setPlayers] = useState<number[]>([]);


### PR DESCRIPTION
## Summary
- cast `dispatch` from `useInterface` to avoid TypeScript `never` error

## Testing
- `npx tsc -p tsconfig.json`
- `npm run build` *(fails: Unknown network: undefined)*

------
https://chatgpt.com/codex/tasks/task_e_684c0c0080988329beecb681fcd1d703