### PR TITLE
Optimize initial fireball casting

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -430,6 +430,17 @@ export function Game({models, sounds, matchId, character}) {
         renderer.shadowMap.type = THREE.VSMShadowMap;
         renderer.toneMapping = THREE.ACESFilmicToneMapping;
 
+        function preloadFireball() {
+            const temp = fireballMesh.clone();
+            temp.visible = false;
+            const tempLight = new THREE.PointLight(0xffaa33, 1, 5);
+            temp.add(tempLight);
+            scene.add(temp);
+            renderer.compile(scene, camera);
+            scene.remove(temp);
+        }
+        preloadFireball();
+
         const stats = new Stats();
 
         stats.domElement.style.position = "absolute";


### PR DESCRIPTION
## Summary
- preload fireball mesh and light to compile shaders on load

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c1f92fb488329a693cc158851c011