### PR TITLE
Add rune buff icon

### DIFF
--- a/server/server.cjs
+++ b/server/server.cjs
@@ -149,7 +149,12 @@ function checkRunePickup(match, playerId) {
                     player.mana = Math.min(100, player.mana + 50);
                     break;
                 case 'damage':
-                    player.buffs.push({type: 'damage', percent: 0.4, expires: Date.now() + 60000});
+                    player.buffs.push({
+                        type: 'damage',
+                        percent: 0.4,
+                        expires: Date.now() + 60000,
+                        icon: '/icons/rune_power.jpg'
+                    });
                     break;
             }
 


### PR DESCRIPTION
## Summary
- show an icon when picking up the damage rune

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c1fd678b0832992e7abf4783a7ebe