### PR TITLE
Update play page with card layout

### DIFF
--- a/client/next-js/app/play/page.tsx
+++ b/client/next-js/app/play/page.tsx
@@ -1,18 +1,9 @@
 "use client";
-import {useWS} from "@/hooks/useWS";
-import React, {useEffect, useState} from "react";
-import {Table, TableHeader, TableColumn, TableBody, TableRow, TableCell, Button, useDisclosure} from "@heroui/react";
-import {
-    Modal,
-    ModalContent,
-    ModalHeader,
-    ModalBody,
-    ModalFooter
-} from "@heroui/modal";
-import {Input} from "@heroui/input";
+
+import Image from "next/image";
+import {Card} from "@heroui/react";
 import {useRouter} from "next/navigation";
 import {Navbar} from "@/components/navbar";
-import {ProfileForm} from "@/components/profile-form";
 import {useCurrentAccount} from "@mysten/dapp-kit";
 import {ConnectionButton} from "@/components/connection-button";
 
@@ -27,11 +18,19 @@ export default function MatchesPage() {
                 account
                     ? (<ConnectionButton />)
                     : (
-                        <div className="max-w-[640px] min-w-[480px] flex gap-8 flex-col">
-                            <Button size='lg' color="primary" onPress={() => router.push('/play/open-world')}>Join Open
-                                World</Button>
-                            <Button size='lg' color="primary" onPress={() => router.push('/matches')}>Join Arena
-                                Match</Button>
+                        <div className="flex w-full h-[calc(100%-98px)] items-center justify-center">
+                            <div className="flex gap-8">
+                                <Card isPressable className="w-64" onPress={() => router.push('/play/open-world')}>
+                                    <Image src="/background.webp" alt="Open World" width={256} height={160}
+                                           className="w-full h-40 object-cover rounded-t-lg"/>
+                                    <div className="p-4 text-center">Join Open World</div>
+                                </Card>
+                                <Card isPressable className="w-64" onPress={() => router.push('/matches')}>
+                                    <Image src="/logo_LoL.png" alt="Arena Match" width={256} height={160}
+                                           className="w-full h-40 object-cover rounded-t-lg"/>
+                                    <div className="p-4 text-center">Join Arena Match</div>
+                                </Card>
+                            </div>
                         </div>
                     )
             }


### PR DESCRIPTION
## Summary
- center options on `/play` using clickable cards

## Testing
- `npx eslint app/play/page.tsx`

------
https://chatgpt.com/codex/tasks/task_e_684c1ec326f48329bc13669ecdc4ddb5