### PR TITLE
Enable auto focus when casting spells

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -840,7 +840,7 @@ export function Game({models, sounds, matchId, character}) {
             const BLINK_COOLDOWN = 10000; // Cooldown in milliseconds
 
             if (!isFocused) {
-                return;
+                handleRightClick();
             }
 
             if (globalSkillCooldown || isCasting || isSkillOnCooldown('blink')) {
@@ -910,7 +910,7 @@ export function Game({models, sounds, matchId, character}) {
             const HEAL_MANA_COST = 30; // Mana cost for healing
 
             if (!isFocused) {
-                return;
+                handleRightClick();
             }
 
             if (globalSkillCooldown || isCasting || isSkillOnCooldown('heal')) {
@@ -1012,7 +1012,7 @@ export function Game({models, sounds, matchId, character}) {
 
         function castSpell(spellType, playerId = myPlayerId) {
             if (!isFocused) {
-                return;
+                handleRightClick();
             }
 
             if (isSkillOnCooldown(spellType)) {


### PR DESCRIPTION
## Summary
- make spells automatically switch to aim mode if not focused

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c22b245348329af72ac88a50a7f00