### PR TITLE
Increase base HP to 200

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -78,7 +78,7 @@ export function Game({models, sounds, matchId, character}) {
         let camera;
         const animations = models["character_animations"];
 
-        let hp = 100,
+        let hp = 200,
             mana = 100;
         let actions = [];
         let playerMixers = [];
@@ -135,7 +135,7 @@ export function Game({models, sounds, matchId, character}) {
 
         // Function to update the HP bar width
         function updateHPBar() {
-            hpBar.style.width = `${hp}%`;
+            hpBar.style.width = `${hp / 2}%`;
         }
 
         // Function to update the Mana bar width
@@ -579,7 +579,7 @@ export function Game({models, sounds, matchId, character}) {
         };
 
         function respawnPlayer() {
-            hp = 100; // Восстанавливаем HP
+            hp = 200; // Восстанавливаем HP
             updateHPBar(); // Обновляем отображение HP
             sendToSocket({type: 'RESPAWN'});
             teleportTo({

--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -34,7 +34,7 @@ export const Interface = () => {
                 <div id="targetPanel" className="target-panel">
                     <div id="targetAddress" className="target-address">{target.address}</div>
                     <div className="bar-container hp-bar-container">
-                        <div className="bar-fill hp-bar-fill" id="targetHpBar" style={{width: `${target.hp}%`}}></div>
+                        <div className="bar-fill hp-bar-fill" id="targetHpBar" style={{width: `${target.hp / 2}%`}}></div>
                     </div>
                     <div className="bar-container mana-bar-container">
                         <div className="bar-fill mana-bar-fill" id="targetManaBar" style={{width: `${target.mana}%`}}></div>

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -100,7 +100,7 @@ function createPlayer(address) {
         deaths: 0,
         assists: 0,
         points: 0,
-        hp: 100,
+        hp: 200,
         mana: 100,
         chests: [],
         address
@@ -143,7 +143,7 @@ function checkRunePickup(match, playerId) {
             match.runes.splice(i, 1);
             switch (rune.type) {
                 case 'heal':
-                    player.hp = Math.min(100, player.hp + 50);
+                    player.hp = Math.min(200, player.hp + 50);
                     break;
                 case 'mana':
                     player.mana = Math.min(100, player.mana + 50);
@@ -443,7 +443,7 @@ ws.on('connection', (socket) => {
 
                         player.mana -= cost;
                         if (message.payload.type === 'heal') {
-                            player.hp = Math.min(100, player.hp + 20);
+                            player.hp = Math.min(200, player.hp + 20);
                         }
 
                         if (['immolate'].includes(message.payload.type)) {
@@ -521,7 +521,7 @@ ws.on('connection', (socket) => {
                 if (match) {
                     const p = match.players.get(id);
                     if (p) {
-                        p.hp = 100;
+                        p.hp = 200;
                         p.mana = 100;
                         broadcastToMatch(match.id, {
                             type: 'UPDATE_STATS',


### PR DESCRIPTION
## Summary
- bump player HP to 200 on server side
- adjust healing limits and respawn value
- update client to expect HP up to 200
- scale HP bars based on new maximum

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c26fbc3788329ba33b276fdb6bdd1