### PR TITLE
Add strength effect for damage rune

### DIFF
--- a/client/next-js/app/matches/[id]/game/page.tsx
+++ b/client/next-js/app/matches/[id]/game/page.tsx
@@ -47,6 +47,7 @@ export default function GamePage() {
         {id: 'mage_staff', path: 'skins/items/mage-staff.glb'},
         {id: 'warlock_staff', path: 'skins/items/warlock-staff.glb'},
         {id: 'ice-veins', path: 'ice-veins.glb'},
+        {id: 'damage_effect', path: 'damage_effect.glb'},
     ];
 
     useLayoutEffect(() => {


### PR DESCRIPTION
## Summary
- preload placeholder `damage_effect` model
- track active damage rune effects
- display red buff effect when a damage rune is picked

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c26062a8c832991eadb4fc7fe27a4