### PR TITLE
Fix HP bar scaling

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -1,4 +1,5 @@
 import React, {useLayoutEffect, useRef, useState} from "react";
+import {MAX_HP} from "../consts";
 import * as THREE from "three";
 import * as SkeletonUtils from "three/examples/jsm/utils/SkeletonUtils";
 import Stats from "three/examples/jsm/libs/stats.module";
@@ -78,7 +79,7 @@ export function Game({models, sounds, matchId, character}) {
         let camera;
         const animations = models["character_animations"];
 
-        let hp = 200,
+        let hp = MAX_HP,
             mana = 100;
         let actions = [];
         let playerMixers = [];
@@ -136,7 +137,7 @@ export function Game({models, sounds, matchId, character}) {
 
         // Function to update the HP bar width
         function updateHPBar() {
-            hpBar.style.width = `${hp / 2}%`;
+            hpBar.style.width = `${(hp / MAX_HP) * 100}%`;
         }
 
         // Function to update the Mana bar width
@@ -580,7 +581,7 @@ export function Game({models, sounds, matchId, character}) {
         };
 
         function respawnPlayer() {
-            hp = 200; // Восстанавливаем HP
+            hp = MAX_HP; // Восстанавливаем HP
             updateHPBar(); // Обновляем отображение HP
             sendToSocket({type: 'RESPAWN'});
             teleportTo({

--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -8,6 +8,7 @@ import {Buffs} from "../parts/Buffs";
 import './Interface.css';
 import Image from "next/image";
 import React, {useEffect, useState} from "react";
+import {MAX_HP} from "../../consts";
 
 export const Interface = () => {
     const [target, setTarget] = useState<{id:number, hp:number, mana:number, address:string}|null>(null);
@@ -34,7 +35,11 @@ export const Interface = () => {
                 <div id="targetPanel" className="target-panel">
                     <div id="targetAddress" className="target-address">{target.address}</div>
                     <div className="bar-container hp-bar-container">
-                        <div className="bar-fill hp-bar-fill" id="targetHpBar" style={{width: `${target.hp / 2}%`}}></div>
+                        <div
+                            className="bar-fill hp-bar-fill"
+                            id="targetHpBar"
+                            style={{width: `${(target.hp / MAX_HP) * 100}%`}}
+                        ></div>
                     </div>
                     <div className="bar-container mana-bar-container">
                         <div className="bar-fill mana-bar-fill" id="targetManaBar" style={{width: `${target.mana}%`}}></div>

--- a/client/next-js/consts/index.ts
+++ b/client/next-js/consts/index.ts
@@ -4,3 +4,6 @@ export const NETWORK = process.env.NEXT_PUBLIC_NETWORK as
   | "testnet"
   | "devnet";
 export const TREASURY_CAP_ID = process.env.NEXT_PUBLIC_TREASURY_CAP_ID;
+
+// Base health for players. Used for health bar calculations on both client and server
+export const MAX_HP = 200;

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -3,6 +3,7 @@ const http = require('http');
 // const { mintChest } = require('./sui.cjs');
 
 const UPDATE_MATCH_INTERVAL = 33;
+const MAX_HP = 200;
 const SPELL_COST = {
     'fireball': 25,
     'darkball': 25,
@@ -100,7 +101,7 @@ function createPlayer(address) {
         deaths: 0,
         assists: 0,
         points: 0,
-        hp: 200,
+        hp: MAX_HP,
         mana: 100,
         chests: [],
         address
@@ -143,7 +144,7 @@ function checkRunePickup(match, playerId) {
             match.runes.splice(i, 1);
             switch (rune.type) {
                 case 'heal':
-                    player.hp = Math.min(200, player.hp + 50);
+                    player.hp = Math.min(MAX_HP, player.hp + 50);
                     break;
                 case 'mana':
                     player.mana = Math.min(100, player.mana + 50);
@@ -443,7 +444,7 @@ ws.on('connection', (socket) => {
 
                         player.mana -= cost;
                         if (message.payload.type === 'heal') {
-                            player.hp = Math.min(200, player.hp + 20);
+                            player.hp = Math.min(MAX_HP, player.hp + 20);
                         }
 
                         if (['immolate'].includes(message.payload.type)) {
@@ -521,7 +522,7 @@ ws.on('connection', (socket) => {
                 if (match) {
                     const p = match.players.get(id);
                     if (p) {
-                        p.hp = 200;
+                        p.hp = MAX_HP;
                         p.mana = 100;
                         broadcastToMatch(match.id, {
                             type: 'UPDATE_STATS',


### PR DESCRIPTION
## Summary
- define a `MAX_HP` constant
- calculate HP bar widths relative to `MAX_HP`
- use the constant on the server when healing or respawning

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*

------
https://chatgpt.com/codex/tasks/task_e_684c2e764bb08329adcecb5b207e7f24