### PR TITLE
Update crosshair highlight logic

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -1004,8 +1004,15 @@ export function Game({models, sounds, matchId, character}) {
                 return;
             }
             const id = getTargetPlayer();
-            if (id) {
-                targetImage.src = '/icons/target-green.svg';
+            if (id && players.has(id)) {
+                const start = playerCollider.end.clone();
+                const targetPos = players.get(id).model.position.clone();
+                const dist = start.distanceTo(targetPos);
+                if (dist <= FIREBLAST_RANGE) {
+                    targetImage.src = '/icons/target-green.svg';
+                } else {
+                    targetImage.src = '/icons/target.svg';
+                }
             } else {
                 targetImage.src = '/icons/target.svg';
             }


### PR DESCRIPTION
## Summary
- highlight crosshair only when another player is within Fireblast range

## Testing
- `npm run lint` *(fails: ESLint couldn't find plugin "eslint-plugin-react")*

------
https://chatgpt.com/codex/tasks/task_e_684c348b55948329813de5d781706292