### PR TITLE
Improve HP/Mana panels using HeroUI

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -138,11 +138,13 @@ export function Game({models, sounds, matchId, character}) {
         // Function to update the HP bar width
         function updateHPBar() {
             hpBar.style.width = `${(hp / MAX_HP) * 100}%`;
+            dispatchEvent('self-update', { hp, mana });
         }
 
         // Function to update the Mana bar width
         function updateManaBar() {
             manaBar.style.width = `${mana}%`;
+            dispatchEvent('self-update', { hp, mana });
         }
 
         function dispatchTargetUpdate() {

--- a/client/next-js/components/layout/Interface.css
+++ b/client/next-js/components/layout/Interface.css
@@ -4,43 +4,6 @@
     width: 100%;
     height: 100%;
 }
-.bar-container {
-    position: relative;
-    width: 150px;
-    height: 20px;
-    border: 2px solid black;
-    border-radius: 15px;
-    overflow: hidden;
-}
-
-/* Specific styles for HP bar */
-.hp-bar-container {
-    top: 100px;
-    left: 20px;
-    background-color: red;
-}
-
-/* Specific styles for Mana bar */
-.mana-bar-container {
-    top: 105px;
-    left: 20px;
-    background-color: gray;
-}
-
-/* General styles for the fill elements */
-.bar-fill {
-    height: 100%;
-}
-
-/* Specific styles for HP fill */
-.hp-bar-fill {
-    background-color: #00FF00;
-}
-
-/* Specific styles for Mana fill */
-.mana-bar-fill {
-    background-color: #0000FF;
-}
 
 /* Styles for the skills bar */
 #skills-bar {
@@ -109,9 +72,6 @@
     z-index: 1000;
 }
 
-#targetPanel .bar-container {
-    margin-top: 4px;
-}
 
 @keyframes floatFade {
     from {

--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -4,6 +4,7 @@ import {Chat} from "../parts/Chat";
 import {Coins} from "../parts/Coins";
 import {Scoreboard} from "../parts/Scoreboard";
 import {Buffs} from "../parts/Buffs";
+import {Progress} from "@heroui/react";
 
 import './Interface.css';
 import Image from "next/image";
@@ -12,6 +13,7 @@ import {MAX_HP} from "../../consts";
 
 export const Interface = () => {
     const [target, setTarget] = useState<{id:number, hp:number, mana:number, address:string}|null>(null);
+    const [selfStats, setSelfStats] = useState<{hp:number, mana:number}>({hp: MAX_HP, mana: 100});
 
     useEffect(() => {
         const handler = (e: CustomEvent) => {
@@ -21,29 +23,26 @@ export const Interface = () => {
         return () => window.removeEventListener('target-update', handler as EventListener);
     }, []);
 
+    useEffect(() => {
+        const handler = (e: CustomEvent) => {
+            setSelfStats(e.detail);
+        };
+        window.addEventListener('self-update', handler as EventListener);
+        return () => window.removeEventListener('self-update', handler as EventListener);
+    }, []);
+
     return (
         <div className="interface-container">
-            <div className="bar-container hp-bar-container">
-                <div className="bar-fill hp-bar-fill" id="hpBar"></div>
-            </div>
-
-            <div className="bar-container mana-bar-container">
-                <div className="bar-fill mana-bar-fill" id="manaBar"></div>
+            <div className="absolute top-24 left-5 w-40 space-y-1">
+                <Progress id="hpBar" aria-label="HP" value={(selfStats.hp / MAX_HP) * 100} color="danger" />
+                <Progress id="manaBar" aria-label="Mana" value={selfStats.mana} color="primary" />
             </div>
 
             {target && (
                 <div id="targetPanel" className="target-panel">
                     <div id="targetAddress" className="target-address">{target.address}</div>
-                    <div className="bar-container hp-bar-container">
-                        <div
-                            className="bar-fill hp-bar-fill"
-                            id="targetHpBar"
-                            style={{width: `${(target.hp / MAX_HP) * 100}%`}}
-                        ></div>
-                    </div>
-                    <div className="bar-container mana-bar-container">
-                        <div className="bar-fill mana-bar-fill" id="targetManaBar" style={{width: `${target.mana}%`}}></div>
-                    </div>
+                    <Progress id="targetHpBar" aria-label="Target HP" value={(target.hp / MAX_HP) * 100} color="danger" className="mb-1 w-40" />
+                    <Progress id="targetManaBar" aria-label="Target Mana" value={target.mana} color="primary" className="w-40" />
                 </div>
             )}
 


### PR DESCRIPTION
## Summary
- dispatch `self-update` event when player's stats change
- replace bar markup with HeroUI `Progress` components
- clean up obsolete CSS for old HP/Mana bars

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c34a341608329b6cfc5e64f28ef1e