### PR TITLE
Add basic item module

### DIFF
--- a/server/sui.cjs
+++ b/server/sui.cjs
@@ -12,6 +12,7 @@ const client = new SuiClient({
 const PACKAGE_ID = '0x9747359e604b83d72dbaaa05ec39558a390138f656085d7abf6604e1805c3546';
 const TREASURY_CAP_OBJECT_ID = '0xa39d534ad0acc77b4d83f099a556d88ac11745c4d4d395b00d99217d9d22ff13';
 const LOOTBOX_CAP_OBJECT_ID = '0x0123456789abcdef';
+const ADMIN_CAP_OBJECT_ID = '0xabcdef0123456789';
 
 // Function to send a mint transaction
 async function mintCoins(recipientAddress, amount) {
@@ -79,6 +80,7 @@ async function mintItem(recipientAddress, itemType) {
         const [it] = tx.moveCall({
             target: `${PACKAGE_ID}::item::create_item`,
             arguments: [
+                tx.object(ADMIN_CAP_OBJECT_ID),
                 tx.pure.string(itemType),
             ],
         });

--- a/smart-contracts/meta_war/sources/admin.move
+++ b/smart-contracts/meta_war/sources/admin.move
@@ -1,0 +1,17 @@
+module meta_war::admin {
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
+    use sui::object;
+
+    /// Capability representing the game administrator
+    public struct AdminCap has key { id: UID }
+
+    /// Create the AdminCap and transfer it to the deployer.
+    /// Should be called once during deployment.
+    public fun init(ctx: &mut TxContext): AdminCap {
+        let cap = AdminCap { id: object::new(ctx) };
+        transfer::public_transfer(cap, tx_context::sender(ctx));
+        cap
+    }
+}

--- a/smart-contracts/meta_war/sources/item.move
+++ b/smart-contracts/meta_war/sources/item.move
@@ -6,6 +6,7 @@ module meta_war::item {
     use sui::coin;
 
     use meta_war::coin::{COIN};
+    use meta_war::admin::{AdminCap};
 
     /// Generic item that can store arbitrary options.
     public struct Item has key {
@@ -23,12 +24,24 @@ module meta_war::item {
     }
 
     /// Create reward table specifying coin reward for each category.
-    public fun create_rewards(simple: u64, rare: u64, epic: u64, ctx: &mut TxContext): RewardTable {
+    /// Requires admin capability to ensure only the server can mint rewards.
+    public fun create_rewards(
+        _cap: &AdminCap,
+        simple: u64,
+        rare: u64,
+        epic: u64,
+        ctx: &mut TxContext,
+    ): RewardTable {
         RewardTable { id: object::new(ctx), simple, rare, epic }
     }
 
     /// Mint new item of given type with empty options table.
-    public fun create_item(item_type: vector<u8>, ctx: &mut TxContext): Item {
+    /// Only callable by holder of the AdminCap.
+    public fun create_item(
+        _cap: &AdminCap,
+        item_type: vector<u8>,
+        ctx: &mut TxContext,
+    ): Item {
         let options = table::new<vector<u8>, vector<u8>>(ctx);
         Item { id: object::new(ctx), item_type, options }
     }

--- a/smart-contracts/meta_war/tests/item_tests
+++ b/smart-contracts/meta_war/tests/item_tests
@@ -7,10 +7,15 @@ module meta_war::item_test {
 
     use meta_war::coin::{Self as mw_coin, COIN};
     use meta_war::item;
+    use meta_war::admin;
 
-    fun cap(ctx: &mut TestContext): &mut coin::TreasuryCap<COIN> acquires coin::TreasuryCap {
-        borrow_global_mut<coin::TreasuryCap<COIN>>(TestContext::sender(ctx))
-    }
+fun cap(ctx: &mut TestContext): &mut coin::TreasuryCap<COIN> acquires coin::TreasuryCap {
+    borrow_global_mut<coin::TreasuryCap<COIN>>(TestContext::sender(ctx))
+}
+
+fun admincap(ctx: &mut TestContext): &mut admin::AdminCap acquires admin::AdminCap {
+    borrow_global_mut<admin::AdminCap>(TestContext::sender(ctx))
+}
 
     fun bal(ctx: &mut TestContext): u64 acquires coin::Coin {
         let addr = TestContext::sender(ctx);
@@ -25,14 +30,18 @@ module meta_war::item_test {
 
     #[test_only]
     public fun test_create_item(ctx: &mut TestContext) {
-        let it = item::create_item(b"sword", ctx);
+        admin::init(ctx);
+        let cap_ref = test::borrow_my_mut<admin::AdminCap>(ctx, 0);
+        let it = item::create_item(&cap_ref, b"sword", ctx);
         assert!(vector::length(&it.item_type) == 5, 0);
         object::delete_object(it);
     }
 
     #[test_only]
     public fun test_add_option(ctx: &mut TestContext) {
-        let mut it = item::create_item(b"shield", ctx);
+        admin::init(ctx);
+        let cap_ref = test::borrow_my_mut<admin::AdminCap>(ctx, 0);
+        let mut it = item::create_item(&cap_ref, b"shield", ctx);
         item::add_option(&mut it, b"def", b"1");
         let val = table::borrow(&it.options, b"def");
         assert!(vector::length(&val) == 1, 0);
@@ -43,7 +52,9 @@ module meta_war::item_test {
     public fun test_award_coins(ctx: &mut TestContext)
             acquires coin::TreasuryCap, coin::Coin {
         mw_coin::init(mw_coin::COIN{}, ctx);
-        let rewards = item::create_rewards(1, 5, 10, ctx);
+        admin::init(ctx);
+        let cap_ref = test::borrow_my_mut<admin::AdminCap>(ctx, 0);
+        let rewards = item::create_rewards(&cap_ref, 1, 5, 10, ctx);
         let start = bal(ctx);
         item::award_coins(&rewards, 1, cap(ctx), TestContext::sender(ctx), ctx);
         assert!(bal(ctx) == start + 10, 0);


### PR DESCRIPTION
## Summary
- add `item` Move module with reward table and item minting
- expose new `mintItem` helper in `sui.cjs`
- add tests exercising the `item` module

## Testing
- `npm test` *(fails: Could not read package.json)*
- `sui move test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da766e7108329b26bbf2c1f17f2d6