### PR TITLE
Add DAO module and tests

### DIFF
--- a/smart-contracts/meta_war/sources/admin.move
+++ b/smart-contracts/meta_war/sources/admin.move
@@ -5,13 +5,13 @@ module meta_war::admin {
     use sui::object;
 
     /// Capability representing the game administrator
-    public struct AdminCap has key { id: UID }
+    public struct AdminCap has key, store { id: UID }
 
     /// Create the AdminCap and transfer it to the deployer.
     /// Should be called once during deployment.
-    public fun init(ctx: &mut TxContext): AdminCap {
+    public fun create_cap(ctx: &mut TxContext): AdminCap {
         let cap = AdminCap { id: object::new(ctx) };
-        transfer::public_transfer(cap, tx_context::sender(ctx));
+        transfer::public_transfer(copy cap, tx_context::sender(ctx));
         cap
     }
 }

--- a/smart-contracts/meta_war/sources/coin.move
+++ b/smart-contracts/meta_war/sources/coin.move
@@ -1,7 +1,10 @@
 module meta_war::coin {
     use sui::coin::{Self, TreasuryCap};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
     use sui::url::new_unsafe_from_bytes;
-
+    use sui::option;
+    use sui::coin;
 
     public struct COIN has drop {}
 

--- a/smart-contracts/meta_war/sources/dao.move
+++ b/smart-contracts/meta_war/sources/dao.move
@@ -1,0 +1,60 @@
+module meta_war::dao {
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
+    use sui::table;
+    use sui::vector;
+
+    use meta_war::admin::{AdminCap};
+
+    const EAlreadyVoted: u64 = 0;
+
+    /// Ticket granting right to participate in DAO voting
+    public struct DaoTicket has key, store { id: UID }
+
+    /// Voting proposal
+    public struct Proposal has key, store {
+        id: UID,
+        description: vector<u8>,
+        yes: u64,
+        no: u64,
+        voters: table::Table<address, bool>,
+    }
+
+    /// Mint DAO ticket. Requires admin cap
+    public fun mint_ticket(_cap: &AdminCap, ctx: &mut TxContext): DaoTicket {
+        DaoTicket { id: object::new(ctx) }
+    }
+
+    /// Create proposal with text description. Requires admin cap
+    public fun create_proposal(
+        _cap: &AdminCap,
+        description: vector<u8>,
+        ctx: &mut TxContext
+    ): Proposal {
+        Proposal {
+            id: object::new(ctx),
+            description,
+            yes: 0,
+            no: 0,
+            voters: table::new<address, bool>(ctx),
+        }
+    }
+
+    /// Vote for proposal using DAO ticket
+    public fun vote(
+        proposal: &mut Proposal,
+        _ticket: &DaoTicket,
+        in_favor: bool,
+        ctx: &mut TxContext
+    ) {
+        let sender = tx_context::sender(ctx);
+        assert!(!table::contains(&proposal.voters, sender), EAlreadyVoted);
+        table::add(&mut proposal.voters, sender, true);
+        if (in_favor) {
+            proposal.yes = proposal.yes + 1
+        } else {
+            proposal.no = proposal.no + 1
+        }
+    }
+}

--- a/smart-contracts/meta_war/tests/dao_tests
+++ b/smart-contracts/meta_war/tests/dao_tests
@@ -1,0 +1,19 @@
+module meta_war::dao_test {
+    use sui::test::{Self, TestContext};
+    use sui::object;
+
+    use meta_war::dao;
+    use meta_war::admin;
+
+    #[test_only]
+    public fun test_vote(ctx: &mut TestContext) {
+        admin::create_cap(ctx);
+        let cap_ref = test::borrow_my_mut<admin::AdminCap>(ctx, 0);
+        let ticket = dao::mint_ticket(&cap_ref, ctx);
+        let mut proposal = dao::create_proposal(&cap_ref, b"test", ctx);
+        dao::vote(&mut proposal, &ticket, true, ctx);
+        assert!(proposal.yes == 1, 0);
+        object::delete_object(ticket);
+        object::delete_object(proposal);
+    }
+}

--- a/smart-contracts/meta_war/tests/item_tests
+++ b/smart-contracts/meta_war/tests/item_tests
@@ -30,7 +30,7 @@ fun admincap(ctx: &mut TestContext): &mut admin::AdminCap acquires admin::AdminC
 
     #[test_only]
     public fun test_create_item(ctx: &mut TestContext) {
-        admin::init(ctx);
+        admin::create_cap(ctx);
         let cap_ref = test::borrow_my_mut<admin::AdminCap>(ctx, 0);
         let it = item::create_item(&cap_ref, b"sword", ctx);
         assert!(vector::length(&it.item_type) == 5, 0);
@@ -39,7 +39,7 @@ fun admincap(ctx: &mut TestContext): &mut admin::AdminCap acquires admin::AdminC
 
     #[test_only]
     public fun test_create_item_with_options(ctx: &mut TestContext) {
-        admin::init(ctx);
+        admin::create_cap(ctx);
         let cap_ref = test::borrow_my_mut<admin::AdminCap>(ctx, 0);
         let mut opts = table::new<vector<u8>, vector<u8>>(ctx);
         table::add(&mut opts, b"class", b"Mage");
@@ -52,7 +52,7 @@ fun admincap(ctx: &mut TestContext): &mut admin::AdminCap acquires admin::AdminC
 
     #[test_only]
     public fun test_add_option(ctx: &mut TestContext) {
-        admin::init(ctx);
+        admin::create_cap(ctx);
         let cap_ref = test::borrow_my_mut<admin::AdminCap>(ctx, 0);
         let mut it = item::create_item(&cap_ref, b"shield", ctx);
         item::add_option(&mut it, b"def", b"1");
@@ -65,7 +65,7 @@ fun admincap(ctx: &mut TestContext): &mut admin::AdminCap acquires admin::AdminC
     public fun test_award_coins(ctx: &mut TestContext)
             acquires coin::TreasuryCap, coin::Coin {
         mw_coin::init(mw_coin::COIN{}, ctx);
-        admin::init(ctx);
+        admin::create_cap(ctx);
         let cap_ref = test::borrow_my_mut<admin::AdminCap>(ctx, 0);
         let rewards = item::create_rewards(&cap_ref, 1, 5, 10, ctx);
         let start = bal(ctx);


### PR DESCRIPTION
## Summary
- introduce `dao` module with ticket minting and proposal voting
- update `admin` capability creation and coin module imports
- add `dao_tests`
- adjust item tests to use new admin API

## Testing
- `sui move test` *(fails: unbound modules and other build errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e0f23cb2c8329ac3cbe4cd368e7f2