### PR TITLE
Remove spell lights and add skill press animation

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -1037,6 +1037,7 @@ export function Game({models, sounds, textures, matchId, character}) {
 
 
         function castSpell(spellType, playerId = myPlayerId) {
+            dispatchEvent('skill-use', { skill: spellType });
             if (!isFocused) {
                 handleRightClick();
             }
@@ -1213,14 +1214,6 @@ export function Game({models, sounds, textures, matchId, character}) {
 
             scene.add(sphereMesh); // Add the sphereMesh to the scene
 
-            const lightColor = {
-                fireball: 0xffaa33,
-                darkball: 0x8844ff,
-                iceball: 0x88ddff,
-            }[type] || 0xffffff;
-            const light = new THREE.PointLight(lightColor, 1, 5);
-            light.position.copy(sphereMesh.position);
-            scene.add(light);
 
             // Compute aim direction based on camera ray and player position
             const aimDir = getAimDirection();
@@ -1275,7 +1268,6 @@ export function Game({models, sounds, textures, matchId, character}) {
                 initialPosition: initialPosition,
                 type,
                 damage,
-                light,
                 ownerId: myPlayerId,
 
                 trail: [], // массив точек следа
@@ -1479,9 +1471,6 @@ export function Game({models, sounds, textures, matchId, character}) {
 
         const removeSphere = (sphere, index) => {
             scene.remove(sphere.mesh); // Remove the fireball from the scene
-            if (sphere.light) {
-                scene.remove(sphere.light);
-            }
             spheres.splice(index, 1); // Remove it from the array
 
             if (sphere.trail) {
@@ -1552,9 +1541,6 @@ export function Game({models, sounds, textures, matchId, character}) {
 
             for (let sphere of spheres) {
                 sphere.mesh.position.copy(sphere.collider.center);
-                if (sphere.light) {
-                    sphere.light.position.copy(sphere.collider.center);
-                }
             }
         }
 

--- a/client/next-js/components/parts/SkillBar.css
+++ b/client/next-js/components/parts/SkillBar.css
@@ -17,6 +17,15 @@
     transform: scale(1.1);
 }
 
+.skill-button:active {
+    transform: scale(0.9);
+}
+
+.skill-button.pressed {
+    transform: scale(0.9);
+    transition-duration: 0.1s;
+}
+
 .skill-icon {
     width: 80%;
     height: 80%;

--- a/client/next-js/components/parts/SkillBar.jsx
+++ b/client/next-js/components/parts/SkillBar.jsx
@@ -23,6 +23,7 @@ export const SkillBar = () => {
     const skills = character?.name === 'warlock' ? WARLOCK_SKILLS : DEFAULT_SKILLS;
 
     const [cooldowns, setCooldowns] = useState({});
+    const [pressed, setPressed] = useState({});
 
     useEffect(() => {
         const handleCooldown = (e) => {
@@ -34,7 +35,19 @@ export const SkillBar = () => {
             }));
         };
         window.addEventListener('skill-cooldown', handleCooldown);
-        return () => window.removeEventListener('skill-cooldown', handleCooldown);
+        const handleSkillUse = (e) => {
+            const {skill} = e.detail || {};
+            if (!skill) return;
+            setPressed((p) => ({...p, [skill]: true}));
+            setTimeout(() => {
+                setPressed((p) => ({...p, [skill]: false}));
+            }, 150);
+        };
+        window.addEventListener('skill-use', handleSkillUse);
+        return () => {
+            window.removeEventListener('skill-cooldown', handleCooldown);
+            window.removeEventListener('skill-use', handleSkillUse);
+        };
     }, []);
 
     useEffect(() => {
@@ -65,7 +78,7 @@ export const SkillBar = () => {
                     text = Math.ceil(remaining / 1000);
                 }
                 return (
-                    <div className="skill-button" key={skill.id}>
+                    <div className={`skill-button${pressed[skill.id] ? ' pressed' : ''}`} key={skill.id}>
                         <div className="skill-icon" style={{backgroundImage: `url('${skill.icon}')`}}></div>
                         {data && (
                             <div className="cooldown-overlay">


### PR DESCRIPTION
## Summary
- dispatch a `skill-use` event when spells are triggered
- remove point lights from projectile spheres
- animate skill bar icons with a `pressed` state
- add CSS for pressed skill buttons

## Testing
- `npm run lint` *(fails: eslint-plugin-react not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd0de1f048329a85fcf53647026d2