### PR TITLE
Reduce player max HP to 120

### DIFF
--- a/client/next-js/consts/index.ts
+++ b/client/next-js/consts/index.ts
@@ -6,4 +6,4 @@ export const NETWORK = process.env.NEXT_PUBLIC_NETWORK as
 export const TREASURY_CAP_ID = process.env.NEXT_PUBLIC_TREASURY_CAP_ID;
 
 // Base health for players. Used for health bar calculations on both client and server
-export const MAX_HP = 200;
+export const MAX_HP = 120;

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -4,7 +4,7 @@ const http = require('http');
 // const { mintCoins, mintItemWithOptions } = require('./sui.cjs');
 
 const UPDATE_MATCH_INTERVAL = 33;
-const MAX_HP = 200;
+const MAX_HP = 120;
 const SPELL_COST = {
     'fireball': 25,
     'darkball': 25,


### PR DESCRIPTION
## Summary
- lower MAX_HP constant for both client and server to 120

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_684fd0f7fd6883298c067c86db142128