### PR TITLE
Add server-controlled respawn system

### DIFF
--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -89,22 +89,7 @@ export const Interface = () => {
 
             <div id="selfDamage" className="self-damage-container"></div>
 
-            <button
-                id="respawnButton"
-                style={{
-                    position: 'absolute',
-                    top: '50%',
-                    left: '50%',
-                    transform: 'translate(-50%, -50%)',
-                    padding: '10px 20px',
-                    fontSize: '20px',
-                    display: 'none', // Скрыто по умолчанию
-                    zIndex: 1000,
-                    pointerEvents: 'auto'
-                }}
-            >
-                Enter for Respawn
-            </button>
+
 
             <Scoreboard />
             <Buffs />


### PR DESCRIPTION
## Summary
- define static spawn points on server and choose one for each player
- assign spawn point when player joins and respawn automatically on death
- broadcast `PLAYER_RESPAWN` to clients on join, match start and after death
- update client to respond to `PLAYER_RESPAWN` events
- remove manual respawn button and enter key handler
- align client spawn positions with server

## Testing
- `npm test` within `server` *(fails: Error: no test specified)*
- `npm test` within `client/next-js` *(fails: Missing script: "test")*
- `npm run lint` within `client/next-js` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*

------
https://chatgpt.com/codex/tasks/task_e_6850306cd3bc83299a10c34553609a09