### PR TITLE
Reduce mana regen and default idle animation

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -2351,7 +2351,12 @@ export function Game({models, sounds, textures, matchId, character}) {
                     address,
                     classType,
                 });
+                idleAction.play();
                 playerMixers.push(mixer);   // массив всех чужих миксеров
+                const pData = players.get(id);
+                if (pData) {
+                    pData.currentAction = 'idle';
+                }
             }
         }
 

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -133,7 +133,7 @@ function createPlayer(address, classType) {
     return {
         position: {...spawn},
         spawn_point: spawn,
-        animationAction: '',
+        animationAction: 'idle',
         rotation: {y: 0},
         buffs: [],
         debuffs: [],
@@ -270,6 +270,7 @@ function applyDamage(match, victimId, dealerId, damage) {
         victim.spawn_point = spawn;
         victim.hp = MAX_HP;
         victim.mana = 100;
+        victim.animationAction = 'idle';
 
         broadcastToMatch(match.id, {
             type: 'PLAYER_RESPAWN',
@@ -315,7 +316,7 @@ ws.on('connection', (socket) => {
         for (const match of matches.values()) {
             match.players.forEach((player, pid) => {
                 if (player.mana < 100) {
-                    player.mana = Math.min(100, player.mana + 3);
+                    player.mana = Math.min(100, player.mana + 2.1);
                 }
                 if (player.buffs.length) {
                     player.buffs = player.buffs.filter(b => b.expires > now);


### PR DESCRIPTION
## Summary
- decrease mana regeneration rate by 30%
- set `animationAction` to `idle` when players spawn or respawn
- start idle animation for character models when created

## Testing
- `npm test --prefix server` *(fails: Error: no test specified)*
- `npm test --prefix client/next-js` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68503475bec483298df6ee7973dfa16c