### PR TITLE
Add profile creation form

### DIFF
--- a/client/next-js/app/play/page.tsx
+++ b/client/next-js/app/play/page.tsx
@@ -1,59 +1,78 @@
 "use client";
 
 import Image from "next/image";
-import {Card, CardHeader} from "@heroui/react";
-import {useRouter} from "next/navigation";
-import {Navbar} from "@/components/navbar";
-import {useCurrentAccount} from "@mysten/dapp-kit";
-import {ConnectionButton} from "@/components/connection-button";
-import {ProfileForm} from "@/components/profile-form";
-import {useProfile} from "@/hooks";
+import { Card, CardHeader } from "@heroui/react";
+import { useRouter } from "next/navigation";
+import { useCurrentAccount } from "@mysten/dapp-kit";
 
+import { Navbar } from "@/components/navbar";
+import { ConnectionButton } from "@/components/connection-button";
+import { ProfileForm } from "@/components/profile-form";
+import { useProfile } from "@/hooks";
 
 export default function MatchesPage() {
-    const router = useRouter();
-    const account = useCurrentAccount();
-    const { profile } = useProfile();
-    return (
-        <div className="h-full w-full  items-center justify-center">
-            <Navbar/>
-            <div className="flex w-full h-[calc(100%-98px)] items-center justify-center">
+  const router = useRouter();
+  const account = useCurrentAccount();
+  const { profile, refetch } = useProfile();
 
-                {
-                    account
-                        ? (
-                            profile ? (
-                                <>
-                                    <div className="flex w-full m-32 gap-8">
-                                        <Card isPressable className="w-2/4 h-[320px]"
-                                              onPress={() => router.push('/play/open-world')}>
-                                            <CardHeader className="pb-0 pt-2 px-4 flex-col items-start">
-                                                <h4 className="font-bold text-large">Join Open World</h4>
-                                            </CardHeader>
-                                            <Image src="/images/open-world.jpg" alt="Open World" width={2000} height={1200}
-                                                   className="w-full h-full object-cover rounded-t-lg"/>
-                                        </Card>
-                                        <Card isPressable className="w-2/4 h-[320px]" onPress={() => router.push('/matches')}>
-                                            <CardHeader className="pb-0 pt-2 px-4 flex-col items-start">
-                                                <h4 className="font-bold text-large">Join Arena Match</h4>
-                                            </CardHeader>
-                                            <Image src="/images/battle.jpg" alt="Arena Match" width={2000} height={1200}
-                                                   className="w-full h-full object-cover rounded-t-lg"/>
-                                        </Card>
-                                    </div>
-                                </>
-                            ) : (
-                                <ProfileForm />
-                            )
-                        )
-                        : (<> 
-                            <Image src="/images/tower_bg.png" alt="Arena Match" width={3000} height={1400}
-                                   className="w-full h-full absolute object-cover rounded-t-lg"/>
-                            <ConnectionButton className="m-auto" text="Connect to Play"/>
-                        </>)
-                }
-            </div>
-
-        </div>
-    );
+  return (
+    <div className="h-full w-full  items-center justify-center">
+      <Navbar />
+      <div className="flex w-full h-[calc(100%-98px)] items-center justify-center">
+        {account ? (
+          profile ? (
+            <>
+              <div className="flex w-full m-32 gap-8">
+                <Card
+                  isPressable
+                  className="w-2/4 h-[320px]"
+                  onPress={() => router.push("/play/open-world")}
+                >
+                  <CardHeader className="pb-0 pt-2 px-4 flex-col items-start">
+                    <h4 className="font-bold text-large">Join Open World</h4>
+                  </CardHeader>
+                  <Image
+                    alt="Open World"
+                    className="w-full h-full object-cover rounded-t-lg"
+                    height={1200}
+                    src="/images/open-world.jpg"
+                    width={2000}
+                  />
+                </Card>
+                <Card
+                  isPressable
+                  className="w-2/4 h-[320px]"
+                  onPress={() => router.push("/matches")}
+                >
+                  <CardHeader className="pb-0 pt-2 px-4 flex-col items-start">
+                    <h4 className="font-bold text-large">Join Arena Match</h4>
+                  </CardHeader>
+                  <Image
+                    alt="Arena Match"
+                    className="w-full h-full object-cover rounded-t-lg"
+                    height={1200}
+                    src="/images/battle.jpg"
+                    width={2000}
+                  />
+                </Card>
+              </div>
+            </>
+          ) : (
+            <ProfileForm onCreated={refetch} />
+          )
+        ) : (
+          <>
+            <Image
+              alt="Arena Match"
+              className="w-full h-full absolute object-cover rounded-t-lg"
+              height={1400}
+              src="/images/tower_bg.png"
+              width={3000}
+            />
+            <ConnectionButton className="m-auto" text="Connect to Play" />
+          </>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/client/next-js/app/play/page.tsx
+++ b/client/next-js/app/play/page.tsx
@@ -6,11 +6,14 @@ import {useRouter} from "next/navigation";
 import {Navbar} from "@/components/navbar";
 import {useCurrentAccount} from "@mysten/dapp-kit";
 import {ConnectionButton} from "@/components/connection-button";
+import {ProfileForm} from "@/components/profile-form";
+import {useProfile} from "@/hooks";
 
 
 export default function MatchesPage() {
     const router = useRouter();
     const account = useCurrentAccount();
+    const { profile } = useProfile();
     return (
         <div className="h-full w-full  items-center justify-center">
             <Navbar/>
@@ -19,27 +22,31 @@ export default function MatchesPage() {
                 {
                     account
                         ? (
-                            <>
-                                <div className="flex w-full m-32 gap-8">
-                                    <Card isPressable className="w-2/4 h-[320px]"
-                                          onPress={() => router.push('/play/open-world')}>
-                                        <CardHeader className="pb-0 pt-2 px-4 flex-col items-start">
-                                            <h4 className="font-bold text-large">Join Open World</h4>
-                                        </CardHeader>
-                                        <Image src="/images/open-world.jpg" alt="Open World" width={2000} height={1200}
-                                               className="w-full h-full object-cover rounded-t-lg"/>
-                                    </Card>
-                                    <Card isPressable className="w-2/4 h-[320px]" onPress={() => router.push('/matches')}>
-                                        <CardHeader className="pb-0 pt-2 px-4 flex-col items-start">
-                                            <h4 className="font-bold text-large">Join Arena Match</h4>
-                                        </CardHeader>
-                                        <Image src="/images/battle.jpg" alt="Arena Match" width={2000} height={1200}
-                                               className="w-full h-full object-cover rounded-t-lg"/>
-                                    </Card>
-                                </div>
-                            </>
+                            profile ? (
+                                <>
+                                    <div className="flex w-full m-32 gap-8">
+                                        <Card isPressable className="w-2/4 h-[320px]"
+                                              onPress={() => router.push('/play/open-world')}>
+                                            <CardHeader className="pb-0 pt-2 px-4 flex-col items-start">
+                                                <h4 className="font-bold text-large">Join Open World</h4>
+                                            </CardHeader>
+                                            <Image src="/images/open-world.jpg" alt="Open World" width={2000} height={1200}
+                                                   className="w-full h-full object-cover rounded-t-lg"/>
+                                        </Card>
+                                        <Card isPressable className="w-2/4 h-[320px]" onPress={() => router.push('/matches')}>
+                                            <CardHeader className="pb-0 pt-2 px-4 flex-col items-start">
+                                                <h4 className="font-bold text-large">Join Arena Match</h4>
+                                            </CardHeader>
+                                            <Image src="/images/battle.jpg" alt="Arena Match" width={2000} height={1200}
+                                                   className="w-full h-full object-cover rounded-t-lg"/>
+                                        </Card>
+                                    </div>
+                                </>
+                            ) : (
+                                <ProfileForm />
+                            )
                         )
-                        : (<>
+                        : (<> 
                             <Image src="/images/tower_bg.png" alt="Arena Match" width={3000} height={1400}
                                    className="w-full h-full absolute object-cover rounded-t-lg"/>
                             <ConnectionButton className="m-auto" text="Connect to Play"/>

--- a/client/next-js/components/profile-form.tsx
+++ b/client/next-js/components/profile-form.tsx
@@ -1,35 +1,35 @@
 "use client";
 
-import {useState} from "react";
-import {Input} from "@heroui/input";
-import {Button} from "@heroui/react";
-import {useTransaction} from "@/hooks";
+import { useState } from "react";
+import { Input } from "@heroui/input";
+import { Button } from "@heroui/react";
 
-export function ProfileForm() {
-    const [nickname, setNickname] = useState("");
-    const {createProfile} = useTransaction();
+import { useTransaction } from "@/hooks";
 
-    const handleCreate = async () => {
-        if (!nickname) return;
-        try {
-            await createProfile(nickname);
-            setNickname("");
-        } catch (e) {
-            console.error(e);
-        }
-    };
-
-    return (
-        <div className="flex gap-2 items-end">
-            <Input
-                label="Nickname"
-                value={nickname}
-                onValueChange={setNickname}
-            />
-            <Button color="primary" onPress={handleCreate} isDisabled={!nickname}>
-                Create Profile
-            </Button>
-        </div>
-    );
+export interface ProfileFormProps {
+  onCreated?: () => void;
 }
+export function ProfileForm({ onCreated }: ProfileFormProps) {
+  const [nickname, setNickname] = useState("");
+  const { createProfile } = useTransaction();
 
+  const handleCreate = async () => {
+    if (!nickname) return;
+    try {
+      await createProfile(nickname);
+      setNickname("");
+      onCreated?.();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <div className="flex gap-2 items-end">
+      <Input label="Nickname" value={nickname} onValueChange={setNickname} />
+      <Button color="primary" isDisabled={!nickname} onPress={handleCreate}>
+        Create Profile
+      </Button>
+    </div>
+  );
+}

--- a/client/next-js/hooks/index.js
+++ b/client/next-js/hooks/index.js
@@ -3,3 +3,4 @@ export * from "./useCoins";
 export * from "./useRatings";
 export * from "./useItems";
 export * from "./useDao";
+export * from "./useProfile";

--- a/client/next-js/hooks/useProfile.ts
+++ b/client/next-js/hooks/useProfile.ts
@@ -1,4 +1,5 @@
 import { useCurrentAccount, useSuiClientQuery } from "@mysten/dapp-kit";
+
 import { PACKAGE_ID } from "@/consts";
 
 export const useProfile = () => {
@@ -7,20 +8,26 @@ export const useProfile = () => {
   const { data, refetch } = useSuiClientQuery(
     "getOwnedObjects",
     {
-      owner: account?.address || "",
+      owner: account?.address as string,
       filter: { StructType: `${PACKAGE_ID}::profile::Profile` },
       options: { showContent: true },
     },
-    { gcTime: 10000 },
+    { gcTime: 10000, enabled: !!account },
   );
 
-  const profileObj = Array.isArray(data?.data) && data.data.length > 0 ? data.data[0] : null;
+  const profileObj =
+    Array.isArray(data?.data) && data.data.length > 0 ? data.data[0] : null;
 
   let nickname: string | null = null;
+
   if (profileObj) {
     const fields = (profileObj as any).data?.content?.fields || {};
     const nickBytes = fields.nickname || [];
-    nickname = typeof nickBytes === "string" ? nickBytes : new TextDecoder().decode(Uint8Array.from(nickBytes));
+
+    nickname =
+      typeof nickBytes === "string"
+        ? nickBytes
+        : new TextDecoder().decode(Uint8Array.from(nickBytes));
   }
 
   return { profile: profileObj, nickname, refetch };

--- a/client/next-js/hooks/useProfile.ts
+++ b/client/next-js/hooks/useProfile.ts
@@ -1,0 +1,27 @@
+import { useCurrentAccount, useSuiClientQuery } from "@mysten/dapp-kit";
+import { PACKAGE_ID } from "@/consts";
+
+export const useProfile = () => {
+  const account = useCurrentAccount();
+
+  const { data, refetch } = useSuiClientQuery(
+    "getOwnedObjects",
+    {
+      owner: account?.address || "",
+      filter: { StructType: `${PACKAGE_ID}::profile::Profile` },
+      options: { showContent: true },
+    },
+    { gcTime: 10000 },
+  );
+
+  const profileObj = Array.isArray(data?.data) && data.data.length > 0 ? data.data[0] : null;
+
+  let nickname: string | null = null;
+  if (profileObj) {
+    const fields = (profileObj as any).data?.content?.fields || {};
+    const nickBytes = fields.nickname || [];
+    nickname = typeof nickBytes === "string" ? nickBytes : new TextDecoder().decode(Uint8Array.from(nickBytes));
+  }
+
+  return { profile: profileObj, nickname, refetch };
+};


### PR DESCRIPTION
## Summary
- add `useProfile` hook to fetch player's profile
- export `useProfile`
- display profile creation form on `/play` if profile not found

## Testing
- `npm run lint` *(fails: ESLint couldn't find plugin eslint-plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_6850ed3a84488329aee1e2fd421a99d5