### PR TITLE
Centralize spell mana costs

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -1,5 +1,6 @@
 import React, {useLayoutEffect, useRef, useState} from "react";
 import {MAX_HP} from "../consts";
+import { SPELL_COST } from '../consts';
 import * as THREE from "three";
 import * as SkeletonUtils from "three/examples/jsm/utils/SkeletonUtils";
 import Stats from "three/examples/jsm/libs/stats.module";
@@ -544,7 +545,7 @@ export function Game({models, sounds, textures, matchId, character}) {
         const maxFOV = 100;
 
         // Shield skill vars
-        const SHIELD_MANA_COST = 40; // Mana cost for the shield
+        const SHIELD_MANA_COST = SPELL_COST['shield'];
         const SHIELD_DURATION = 3; // Shield duration in seconds
         const DAMAGE_REDUCTION = 0.5; // Reduces damage by 50%
         const ICE_VEINS_ROT_SPEED = 1; // Rotation speed for Ice Veins effect (horizontal)
@@ -861,7 +862,7 @@ export function Game({models, sounds, textures, matchId, character}) {
 
         function castBlink() {
             const BLINK_DISTANCE = 5; // Distance to teleport forward
-            const BLINK_MANA_COST = 20; // Mana cost for blink
+            const BLINK_MANA_COST = SPELL_COST['blink'];
             const BLINK_COOLDOWN = 10000; // Cooldown in milliseconds
 
             if (!isFocused) {
@@ -932,7 +933,7 @@ export function Game({models, sounds, textures, matchId, character}) {
 
         function castHeal() {
             const HEAL_AMOUNT = 20; // Amount of HP restored
-            const HEAL_MANA_COST = 30; // Mana cost for healing
+            const HEAL_MANA_COST = SPELL_COST['heal'];
 
             if (!isFocused) {
                 handleRightClick();

--- a/client/next-js/consts/index.ts
+++ b/client/next-js/consts/index.ts
@@ -7,3 +7,4 @@ export const TREASURY_CAP_ID = process.env.NEXT_PUBLIC_TREASURY_CAP_ID;
 
 // Base health for players. Used for health bar calculations on both client and server
 export const MAX_HP = 120;
+export { default as SPELL_COST } from './spellCosts.json';

--- a/client/next-js/consts/spellCosts.json
+++ b/client/next-js/consts/spellCosts.json
@@ -1,0 +1,13 @@
+{
+  "fireball": 35,
+  "darkball": 35,
+  "corruption": 35,
+  "immolate": 35,
+  "iceball": 50,
+  "fireblast": 35,
+  "conflagrate": 35,
+  "shield": 80,
+  "blink": 35,
+  "heal": 35,
+  "ice-veins": 60
+}

--- a/client/next-js/skills/mage/fireball.js
+++ b/client/next-js/skills/mage/fireball.js
@@ -1,10 +1,12 @@
+import { SPELL_COST } from '../../consts';
+
 export const meta = { id: 'fireball', key: 'E', icon: '/icons/fireball.png' };
 
 export default function castFireball({ playerId, castSpellImpl, igniteHands, castSphere, fireballMesh, sounds, damage }) {
   igniteHands(playerId, 1000);
   castSpellImpl(
     playerId,
-    40,
+    SPELL_COST['fireball'],
     0,
     (model) => castSphere(model, fireballMesh.clone(), meta.id, damage),
     sounds.fireballCast,

--- a/client/next-js/skills/mage/fireblast.js
+++ b/client/next-js/skills/mage/fireblast.js
@@ -1,8 +1,10 @@
+import { SPELL_COST } from '../../consts';
+
 export const meta = { id: 'fireblast', key: 'Q', icon: '/icons/spell_fire_fireball.jpg' };
 
 export default function castFireblast({ playerId, globalSkillCooldown, isCasting, mana, getTargetPlayer, dispatch, sendToSocket, activateGlobalCooldown, startSkillCooldown, FIREBLAST_DAMAGE, sounds }) {
   if (globalSkillCooldown || isCasting) return;
-  if (mana < 30) {
+  if (mana < SPELL_COST['fireblast']) {
     console.log('Not enough mana for fireblast!');
     if (sounds?.noMana) {
       sounds.noMana.currentTime = 0;

--- a/client/next-js/skills/mage/iceVeins.js
+++ b/client/next-js/skills/mage/iceVeins.js
@@ -1,9 +1,9 @@
+import { SPELL_COST } from '../../consts';
+
 export const meta = { id: 'ice-veins', key: 'F', icon: '/icons/spell_veins.jpg' };
 
-export const ICE_VEINS_MANA_COST = 50;
-
 export default function castIceVeins({ playerId, activateIceVeins, mana, sounds }) {
-  if (mana < ICE_VEINS_MANA_COST) {
+  if (mana < SPELL_COST['ice-veins']) {
     console.log('Not enough mana for ice veins!');
     if (sounds?.noMana) {
       sounds.noMana.currentTime = 0;

--- a/client/next-js/skills/mage/iceball.js
+++ b/client/next-js/skills/mage/iceball.js
@@ -1,10 +1,12 @@
+import { SPELL_COST } from '../../consts';
+
 export const meta = { id: 'iceball', key: 'R', icon: '/icons/spell_frostbolt.jpg' };
 
 export default function castIceball({ playerId, castSpellImpl, freezeHands, castSphere, iceballMesh, sounds, damage }) {
   freezeHands(playerId, 1000);
   castSpellImpl(
     playerId,
-    60,
+    SPELL_COST['iceball'],
     0,
     (model) => castSphere(model, iceballMesh.clone(), meta.id, damage),
     sounds.iceballCast,

--- a/client/next-js/skills/warlock/conflagrate.js
+++ b/client/next-js/skills/warlock/conflagrate.js
@@ -1,3 +1,5 @@
+import { SPELL_COST } from '../../consts';
+
 export const meta = { id: 'conflagrate', key: 'F', icon: '/icons/spell_fire_fireball.jpg' };
 
 export default function castConflagrate({
@@ -15,7 +17,7 @@ export default function castConflagrate({
   sounds,
 }) {
   if (globalSkillCooldown || isCasting) return;
-  if (mana < 20) {
+  if (mana < SPELL_COST['conflagrate']) {
     console.log('Not enough mana for conflagrate!');
     if (sounds?.noMana) {
       sounds.noMana.currentTime = 0;

--- a/client/next-js/skills/warlock/corruption.js
+++ b/client/next-js/skills/warlock/corruption.js
@@ -1,8 +1,10 @@
+import { SPELL_COST } from '../../consts';
+
 export const meta = { id: 'corruption', key: 'R', icon: '/icons/spell_corruption.jpg' };
 
 export default function castCorruption({ playerId, globalSkillCooldown, isCasting, mana, getTargetPlayer, dispatch, sendToSocket, activateGlobalCooldown, startSkillCooldown, sounds }) {
   if (globalSkillCooldown || isCasting) return;
-  if (mana < 30) {
+  if (mana < SPELL_COST['corruption']) {
     console.log('Not enough mana for corruption!');
     if (sounds?.noMana) {
       sounds.noMana.currentTime = 0;

--- a/client/next-js/skills/warlock/darkball.js
+++ b/client/next-js/skills/warlock/darkball.js
@@ -1,10 +1,12 @@
+import { SPELL_COST } from '../../consts';
+
 export const meta = { id: 'darkball', key: 'E', icon: '/icons/spell_shadowbolt.jpg' };
 
 export default function castDarkball({ playerId, castSpellImpl, igniteHands, castSphere, darkballMesh, sounds, damage }) {
   igniteHands(playerId, 1000);
   castSpellImpl(
     playerId,
-    30,
+    SPELL_COST['darkball'],
     0,
     (model) => castSphere(model, darkballMesh.clone(), meta.id, damage),
     sounds.fireballCast,

--- a/client/next-js/skills/warlock/immolate.js
+++ b/client/next-js/skills/warlock/immolate.js
@@ -1,3 +1,5 @@
+import { SPELL_COST } from '../../consts';
+
 export const meta = { id: 'immolate', key: 'Q', icon: '/icons/spell_immolation.jpg' };
 
 export default function castImmolate({
@@ -10,7 +12,7 @@ export default function castImmolate({
   sendToSocket,
   sounds,
 }) {
-  if (mana < 30) {
+  if (mana < SPELL_COST['immolate']) {
     console.log('Not enough mana for immolate!');
     if (sounds?.noMana) {
       sounds.noMana.currentTime = 0;
@@ -30,7 +32,7 @@ export default function castImmolate({
   igniteHands(playerId, 1500);
   castSpellImpl(
     playerId,
-    30,
+    SPELL_COST['immolate'],
     1500,
     () => {
       sendToSocket({ type: 'CAST_SPELL', payload: { type: 'immolate', targetId } });

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -5,19 +5,9 @@ const http = require('http');
 
 const UPDATE_MATCH_INTERVAL = 33;
 const MAX_HP = 120;
-const SPELL_COST = {
-    'fireball': 25,
-    'darkball': 25,
-    'corruption': 30,
-    'immolate': 30,
-    'iceball': 35,
-    'fireblast': 30,
-    'conflagrate': 20,
-    'shield': 80,
-    'blink': 20,
-    'heal': 30,
-    'ice-veins': 50,
-};
+const MANA_REGEN_INTERVAL = 1000;
+const MANA_REGEN_AMOUNT = 1;
+const SPELL_COST = require('../client/next-js/consts/spellCosts.json');
 
 const RUNE_POSITIONS = [
     {x: -26.961362434513486, y: 0.7993884353993412, z: -0.268686138846919},
@@ -316,7 +306,7 @@ ws.on('connection', (socket) => {
         for (const match of matches.values()) {
             match.players.forEach((player, pid) => {
                 if (player.mana < 100) {
-                    player.mana = Math.min(100, player.mana + 1);
+                    player.mana = Math.min(100, player.mana + MANA_REGEN_AMOUNT);
                 }
                 if (player.buffs.length) {
                     player.buffs = player.buffs.filter(b => b.expires > now);
@@ -342,7 +332,7 @@ ws.on('connection', (socket) => {
                 }
             });
         }
-    }, 500);
+    }, MANA_REGEN_INTERVAL);
 
     socket.on('message', (data) => {
         let message = {};


### PR DESCRIPTION
## Summary
- centralize mana costs in a shared `spellCosts.json`
- import `SPELL_COST` from constants in client skills and game logic
- load `SPELL_COST` in the server

## Testing
- `npm test` in `server` *(fails: Error: no test specified)*
- `npm run lint` in `client/next-js` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_6850f5fd0a448329b410d89593e67129