### PR TITLE
Reduce spell projectile speed

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -491,8 +491,8 @@ export function Game({models, sounds, textures, matchId, character}) {
         const DARKBALL_DAMAGE = 30;
 
         // Медленнее пускаем сферы как настоящие заклинания
-        const MIN_SPHERE_IMPULSE = 15;
-        const MAX_SPHERE_IMPULSE = 30;
+        const MIN_SPHERE_IMPULSE = 12;
+        const MAX_SPHERE_IMPULSE = 24;
 
         // Maximum distance any sphere can travel
         // Use the same range as fireblast for consistency


### PR DESCRIPTION
## Summary
- tweak sphere impulse constants to slow projectile speed

## Testing
- `npm test --silent` in `client/next-js`
- `npm test --prefix server --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850f8ca65e08329b0b45058a7e16c8c