### PR TITLE
Add skill icons to damage labels

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -17,20 +17,31 @@ import {useWS} from "../hooks/useWS";
 import {world} from "../worlds/main/data";
 
 // spell implementations
-import castFireball from '../skills/mage/fireball';
-import castIceball from '../skills/mage/iceball';
-import castFireblast from '../skills/mage/fireblast';
-import castIceVeins from '../skills/mage/iceVeins';
-import castDarkball from '../skills/warlock/darkball';
-import castCorruption from '../skills/warlock/corruption';
-import castImmolate from '../skills/warlock/immolate';
-import castConflagrate from '../skills/warlock/conflagrate';
+import castFireball, { meta as fireballMeta } from '../skills/mage/fireball';
+import castIceball, { meta as iceballMeta } from '../skills/mage/iceball';
+import castFireblast, { meta as fireblastMeta } from '../skills/mage/fireblast';
+import castIceVeins, { meta as iceVeinsMeta } from '../skills/mage/iceVeins';
+import castDarkball, { meta as darkballMeta } from '../skills/warlock/darkball';
+import castCorruption, { meta as corruptionMeta } from '../skills/warlock/corruption';
+import castImmolate, { meta as immolateMeta } from '../skills/warlock/immolate';
+import castConflagrate, { meta as conflagrateMeta } from '../skills/warlock/conflagrate';
 
 
 import {Interface} from "@/components/layout/Interface";
 import * as iceShieldMesh from "three/examples/jsm/utils/SkeletonUtils";
 import {Loading} from "@/components/loading";
 import { Countdown } from "./parts/Countdown";
+
+const SPELL_ICONS = {
+    [fireballMeta.id]: fireballMeta.icon,
+    [iceballMeta.id]: iceballMeta.icon,
+    [fireblastMeta.id]: fireblastMeta.icon,
+    [iceVeinsMeta.id]: iceVeinsMeta.icon,
+    [darkballMeta.id]: darkballMeta.icon,
+    [corruptionMeta.id]: corruptionMeta.icon,
+    [immolateMeta.id]: immolateMeta.icon,
+    [conflagrateMeta.id]: conflagrateMeta.icon,
+};
 
 const USER_DEFAULT_POSITION = [
     -36.198117096583466, 0.22499999997500564, -11.704829764915257,
@@ -2399,7 +2410,7 @@ export function Game({models, sounds, textures, matchId, character}) {
             }
         }
 
-        function showDamage(playerId, amount) {
+        function showDamage(playerId, amount, spellType) {
             const player = players.get(playerId)?.model;
             if (!player) return;
 
@@ -2416,7 +2427,18 @@ export function Game({models, sounds, textures, matchId, character}) {
 
             const div = document.createElement('div');
             div.className = 'damage-label';
-            div.textContent = String(amount);
+
+            const iconSrc = SPELL_ICONS[spellType];
+            if (iconSrc) {
+                const img = document.createElement('img');
+                img.src = iconSrc;
+                img.className = 'damage-icon';
+                div.appendChild(img);
+            }
+
+            const span = document.createElement('span');
+            span.textContent = String(amount);
+            div.appendChild(span);
             record.container.prepend(div);
 
             if (record.container.childElementCount > 3) {
@@ -2600,7 +2622,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                     break;
                 case "DAMAGE":
                     if (message.targetId) {
-                        showDamage(message.targetId, message.amount);
+                        showDamage(message.targetId, message.amount, message.spellType);
                         if (message.targetId === myPlayerId) {
                             showSelfDamage(message.amount);
                             sounds.damage.volume = 0.5;

--- a/client/next-js/components/layout/Interface.css
+++ b/client/next-js/components/layout/Interface.css
@@ -35,7 +35,20 @@
     font-weight: 800;
     font-size: 16px;
     pointer-events: none;
+    display: flex;
+    align-items: center;
+    gap: 4px;
     animation: floatFade 1s ease-out forwards;
+}
+
+.damage-icon {
+    width: 16px;
+    height: 16px;
+}
+
+#selfDamage .damage-icon {
+    width: 24px;
+    height: 24px;
 }
 
 .damage-label-container {

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -236,7 +236,7 @@ function checkRunePickup(match, playerId) {
     }
 }
 
-function applyDamage(match, victimId, dealerId, damage) {
+function applyDamage(match, victimId, dealerId, damage, spellType) {
     const victim = match.players.get(victimId);
     if (!victim) return;
     const attacker = match.players.get(dealerId);
@@ -294,6 +294,7 @@ function applyDamage(match, victimId, dealerId, damage) {
         type: 'DAMAGE',
         targetId: victimId,
         amount: totalDamage,
+        spellType,
     });
 }
 
@@ -329,7 +330,7 @@ ws.on('connection', (socket) => {
                     player.debuffs = player.debuffs.filter(deb => {
                         if (deb.nextTick !== undefined && deb.nextTick <= now) {
                             deb.nextTick = now + deb.interval;
-                            applyDamage(match, pid, deb.casterId, deb.damage);
+                            applyDamage(match, pid, deb.casterId, deb.damage, deb.type);
                             deb.ticks--;
                         }
 
@@ -635,7 +636,7 @@ ws.on('connection', (socket) => {
 
             case 'TAKE_DAMAGE':
                 if (match) {
-                    applyDamage(match, id, message.damageDealerId, message.damage);
+                    applyDamage(match, id, message.damageDealerId, message.damage, message.spellType);
                     if (message.spellType === 'iceball') {
                         const target = match.players.get(id);
                         if (target) {


### PR DESCRIPTION
## Summary
- show which skill dealt damage in floating labels
- include skill images next to damage values
- send spell type info with DAMAGE messages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68513ad7879c832994f01a34ee1013da