### PR TITLE
Increase mana regeneration speed

### DIFF
--- a/server/server.cjs
+++ b/server/server.cjs
@@ -6,7 +6,7 @@ const http = require('http');
 const UPDATE_MATCH_INTERVAL = 33;
 const MAX_HP = 120;
 const MANA_REGEN_INTERVAL = 1000;
-const MANA_REGEN_AMOUNT = 1;
+const MANA_REGEN_AMOUNT = 1.3; // 30% faster mana regeneration
 const SPELL_COST = require('../client/next-js/consts/spellCosts.json');
 
 const RUNE_POSITIONS = [


### PR DESCRIPTION
## Summary
- speed up mana regeneration by 30%

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68515d3beddc83299d6e618b2b8fdbe6