### PR TITLE
Improve spell visuals and stat display

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -312,18 +312,23 @@ export function Game({models, sounds, textures, matchId, character}) {
             SPELL_SCALES.pyroblast,
         );
 
+        const darkballFragmentShader = fireballMaterial.fragmentShader.replace(
+            'gl_FragColor = vec4(col, alpha);',
+            'gl_FragColor = vec4(col, min(1.0, alpha * 1.5));'
+        );
+
         const darkballMaterial = new THREE.ShaderMaterial({
             transparent: true,
-            depthWrite: false,
-            blending: THREE.AdditiveBlending,
+            depthWrite: true,
+            blending: THREE.NormalBlending,
             uniforms: {
                 time: {value: 0},
-                coreCol: {value: new THREE.Color(0x8a2be2)},
-                flameCol: {value: new THREE.Color(0x160033)},
+                coreCol: {value: new THREE.Color(0xb84dff)},
+                flameCol: {value: new THREE.Color(0x220044)},
                 fireTex: {value: fireTexture},
             },
             vertexShader: fireballMaterial.vertexShader,
-            fragmentShader: fireballMaterial.fragmentShader,
+            fragmentShader: darkballFragmentShader,
         });
         const darkballMesh = new THREE.Mesh(
             fireballGeometry,

--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -46,10 +46,10 @@ export const Interface = () => {
                     </div>
                 )}
                 <div className="w-40 space-y-1">
-                    <p className="text-medium font-semibold">HP: {(selfStats.hp / MAX_HP) * 100}</p>
-                    <Progress id="hpBar" aria-label="HP" value={(selfStats.hp / MAX_HP) * 100} color="secondary" disableAnimation />
-                    <p className="text-medium font-semibold">Mana: {selfStats.mana}</p>
-                    <Progress id="manaBar" aria-label="Mana" value={selfStats.mana} color="primary" disableAnimation />
+                    <p className="text-medium font-semibold">HP: {Math.round((selfStats.hp / MAX_HP) * 100)}</p>
+                    <Progress id="hpBar" aria-label="HP" value={Math.round((selfStats.hp / MAX_HP) * 100)} color="secondary" disableAnimation />
+                    <p className="text-medium font-semibold">Mana: {Math.round(selfStats.mana)}</p>
+                    <Progress id="manaBar" aria-label="Mana" value={Math.round(selfStats.mana)} color="primary" disableAnimation />
                 </div>
             </div>
 
@@ -62,10 +62,10 @@ export const Interface = () => {
                     )}
                     <div className="flex flex-col">
                         <div id="targetAddress" className="target-address">{target.address}</div>
-                        <p className="text-medium font-semibold">HP: {(target.hp / MAX_HP) * 100}</p>
-                        <Progress id="targetHpBar" aria-label="Target HP" value={(target.hp / MAX_HP) * 100} color="secondary" className="mb-1 w-40" disableAnimation />
-                        <p className="text-medium font-semibold">Mana: {target.mana}</p>
-                        <Progress id="targetManaBar" aria-label="Target Mana" value={target.mana} color="primary" className="w-40" disableAnimation />
+                        <p className="text-medium font-semibold">HP: {Math.round((target.hp / MAX_HP) * 100)}</p>
+                        <Progress id="targetHpBar" aria-label="Target HP" value={Math.round((target.hp / MAX_HP) * 100)} color="secondary" className="mb-1 w-40" disableAnimation />
+                        <p className="text-medium font-semibold">Mana: {Math.round(target.mana)}</p>
+                        <Progress id="targetManaBar" aria-label="Target Mana" value={Math.round(target.mana)} color="primary" className="w-40" disableAnimation />
                     </div>
                 </div>
             )}


### PR DESCRIPTION
## Summary
- make darkball and chaosBolt more visible
- round HP and mana display values

## Testing
- `npx -y eslint@8 -c .eslintrc.json components/game.jsx components/layout/Interface.tsx --fix`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68516a2e615c8329bb40a1a26db96e6d