### PR TITLE
Fix chaosbolt mana cost

### DIFF
--- a/client/next-js/consts/spellCosts.json
+++ b/client/next-js/consts/spellCosts.json
@@ -9,5 +9,5 @@
   "blink": 35,
   "heal": 35,
   "pyroblast": 70,
-  "chaosBolt": 70
+  "chaosbolt": 70
 }

--- a/client/next-js/skills/warlock/chaosBolt.js
+++ b/client/next-js/skills/warlock/chaosBolt.js
@@ -6,7 +6,7 @@ export default function castChaosBolt({ playerId, castSpellImpl, igniteHands, ca
   igniteHands(playerId, 1000);
   castSpellImpl(
     playerId,
-    SPELL_COST['chaosBolt'],
+    SPELL_COST['chaosbolt'],
     0,
     (model) => castSphere(model, chaosBoltMesh.clone(), meta.id, damage),
     sounds.fireballCast,


### PR DESCRIPTION
## Summary
- align chaosbolt mana cost key with other spells
- update chaosbolt skill to use the correct key

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react"*)

------
https://chatgpt.com/codex/tasks/task_e_68516a9bef548329b703a97adc416dec