### PR TITLE
Fix sphere flicker

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -260,8 +260,8 @@ export function Game({models, sounds, textures, matchId, character}) {
                   vUv  = uv;
                   float n = noise(position.xy * 4.0 + time*2.0);
                   vNoise = n;
-                  vec3 displaced = position + normal * (0.1 + 0.05 * n) * sin((position.z + time) * 8.0);
-                  gl_Position = projectionMatrix * modelViewMatrix * vec4(displaced,1.0);
+                  // keep sphere size static during flight
+                  gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0);
                 }`,
             fragmentShader: /* glsl */`
                 uniform float time;
@@ -373,8 +373,8 @@ export function Game({models, sounds, textures, matchId, character}) {
       vUv = uv;
       float n = noise3(position*10.0 + time*2.0);
       vNoise = n;
-      vec3 displaced = position + normal * 0.05 * n;
-      gl_Position = projectionMatrix * modelViewMatrix * vec4(displaced,1.0);
+      // keep sphere size static during flight
+      gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0);
     }
   `,
             fragmentShader: `


### PR DESCRIPTION
## Summary
- keep projectile meshes a constant size by removing vertex displacement
- maintain glow by still using noise-driven color

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_685174f929888329a551842d1ca61316