### PR TITLE
Add player points and XP runes

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -95,6 +95,7 @@ export function Game({models, sounds, textures, matchId, character}) {
         // Store other players
         const players = new Map();
         const runes = new Map();
+        const xpRunes = new Map();
         const damageLabels = new Map();
         let myPlayerId = null;
 
@@ -2434,6 +2435,33 @@ export function Game({models, sounds, textures, matchId, character}) {
             }
         }
 
+        function createXpRune(data) {
+            const modelId = 'mana_rune';
+            const base = models[modelId];
+            if (!base) return;
+            const rune = SkeletonUtils.clone(base);
+            rune.position.set(data.position.x, data.position.y, data.position.z);
+            rune.scale.multiplyScalar(0.2);
+            rune.traverse((child) => {
+                if (child.isMesh) {
+                    child.material = child.material.clone();
+                }
+            });
+            const glow = makeGlowSprite(0xffff00, 1.5);
+            glow.position.y = 0.2;
+            rune.add(glow);
+            scene.add(rune);
+            xpRunes.set(data.id, rune);
+        }
+
+        function removeXpRune(id) {
+            const rune = xpRunes.get(id);
+            if (rune) {
+                scene.remove(rune);
+                xpRunes.delete(id);
+            }
+        }
+
         // Function to remove a player from the scene
         function removePlayer(id) {
             if (players.has(id)) {
@@ -2673,7 +2701,11 @@ export function Game({models, sounds, textures, matchId, character}) {
                     }
                     break;
                 case "RUNE_PICKED":
-                    removeRune(message.runeId);
+                    if (message.runeType === 'xp') {
+                        removeXpRune(message.runeId);
+                    } else {
+                        removeRune(message.runeId);
+                    }
                     if (message.runeType === 'damage') {
                         applyDamageRuneEffect(message.playerId);
                     }
@@ -2688,6 +2720,9 @@ export function Game({models, sounds, textures, matchId, character}) {
                                 break;
                             case 'damage':
                                 text = 'Damage buff for 60s!';
+                                break;
+                            case 'xp':
+                                text = 'Gained experience!';
                                 break;
                         }
                         if (text) {
@@ -2729,10 +2764,12 @@ export function Game({models, sounds, textures, matchId, character}) {
                         id: Number(id),
                         kills: p.kills,
                         deaths: p.deaths,
+                        points: p.points,
                     }));
                     dispatch({type: 'SET_SCOREBOARD_DATA', payload: boardData});
 
                     const runeIds = new Set();
+                    const xpRuneIds = new Set();
                     if (Array.isArray(message.runes)) {
                         message.runes.forEach(r => {
                             runeIds.add(r.id);
@@ -2744,9 +2781,25 @@ export function Game({models, sounds, textures, matchId, character}) {
                             }
                         });
                     }
+                    if (Array.isArray(message.xpRunes)) {
+                        message.xpRunes.forEach(r => {
+                            xpRuneIds.add(r.id);
+                            if (!xpRunes.has(r.id)) {
+                                createXpRune(r);
+                            } else {
+                                const obj = xpRunes.get(r.id);
+                                obj.position.set(r.position.x, r.position.y, r.position.z);
+                            }
+                        });
+                    }
                     Array.from(runes.keys()).forEach(id => {
                         if (!runeIds.has(id)) {
                             removeRune(id);
+                        }
+                    });
+                    Array.from(xpRunes.keys()).forEach(id => {
+                        if (!xpRuneIds.has(id)) {
+                            removeXpRune(id);
                         }
                     });
 

--- a/client/next-js/components/parts/Scoreboard.jsx
+++ b/client/next-js/components/parts/Scoreboard.jsx
@@ -14,6 +14,7 @@ export const Scoreboard = () => {
                     <th>Player</th>
                     <th>Kills</th>
                     <th>Deaths</th>
+                    <th>Points</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -22,6 +23,7 @@ export const Scoreboard = () => {
                         <td>{`Player ${p.id}`}</td>
                         <td>{p.kills}</td>
                         <td>{p.deaths}</td>
+                        <td>{p.points}</td>
                     </tr>
                 ))}
                 </tbody>


### PR DESCRIPTION
## Summary
- introduce player points and check for 1000 points to end the match
- add XP rune positions and handling on server
- regenerate and broadcast XP runes
- handle XP rune pickup and award points
- display points on the scoreboard
- sync points and XP runes on client

## Testing
- `npm test` in `server` *(fails: Error: no test specified)*
- `npm test` in `client/next-js` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68527c66970883299fa2e706f626014d