### PR TITLE
Add XP rune sound effect

### DIFF
--- a/client/next-js/app/matches/[id]/game/page.tsx
+++ b/client/next-js/app/matches/[id]/game/page.tsx
@@ -122,6 +122,7 @@ export default function GamePage() {
       noMana: new Audio("/sounds/no-mana.ogg"),
       noTarget: new Audio("/sounds/no-target.ogg"),
       cooldown: new Audio("/sounds/cooldown.ogg"),
+      xpRune: new Audio("/sounds/xp-rune.ogg"),
     };
 
     Promise.all([preloadModels(models), preloadTextures()]).then(

--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -2703,6 +2703,11 @@ export function Game({models, sounds, textures, matchId, character}) {
                                 text = 'Gained experience!';
                                 break;
                         }
+                        if (message.runeType === 'xp' && sounds?.xpRune) {
+                            sounds.xpRune.currentTime = 0;
+                            sounds.xpRune.volume = 0.5;
+                            sounds.xpRune.play();
+                        }
                         if (text) {
                             dispatch({type: 'SEND_CHAT_MESSAGE', payload: text});
                         }


### PR DESCRIPTION
## Summary
- play a sound when picking up an XP rune
- preload new `/sounds/xp-rune.ogg` asset

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin `eslint-plugin-react`)*

------
https://chatgpt.com/codex/tasks/task_e_68528ddb78b483298334183cdaf28497