### PR TITLE
Add rune sound effects

### DIFF
--- a/client/next-js/app/matches/[id]/game/page.tsx
+++ b/client/next-js/app/matches/[id]/game/page.tsx
@@ -123,6 +123,9 @@ export default function GamePage() {
       noTarget: new Audio("/sounds/no-target.ogg"),
       cooldown: new Audio("/sounds/cooldown.ogg"),
       xpRune: new Audio("/sounds/xp-rune.ogg"),
+      healRune: new Audio("/sounds/heal-rune.ogg"),
+      manaRune: new Audio("/sounds/mana-rune.ogg"),
+      damageRune: new Audio("/sounds/damage-rune.ogg"),
     };
 
     Promise.all([preloadModels(models), preloadTextures()]).then(

--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -2708,6 +2708,21 @@ export function Game({models, sounds, textures, matchId, character}) {
                             sounds.xpRune.volume = 0.5;
                             sounds.xpRune.play();
                         }
+                        if (message.runeType === 'heal' && sounds?.healRune) {
+                            sounds.healRune.currentTime = 0;
+                            sounds.healRune.volume = 0.5;
+                            sounds.healRune.play();
+                        }
+                        if (message.runeType === 'mana' && sounds?.manaRune) {
+                            sounds.manaRune.currentTime = 0;
+                            sounds.manaRune.volume = 0.5;
+                            sounds.manaRune.play();
+                        }
+                        if (message.runeType === 'damage' && sounds?.damageRune) {
+                            sounds.damageRune.currentTime = 0;
+                            sounds.damageRune.volume = 0.5;
+                            sounds.damageRune.play();
+                        }
                         if (text) {
                             dispatch({type: 'SEND_CHAT_MESSAGE', payload: text});
                         }


### PR DESCRIPTION
## Summary
- preload new rune sound effects
- play a specific sound when picking up heal, mana, or damage runes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68529bd654c48329b089a31828347457