### PR TITLE
Add camera direction logging to J key

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -744,6 +744,11 @@ export function Game({models, sounds, textures, matchId, character}) {
                     console.log(
                         `Player position: x=${currentPosition.x}, y=${currentPosition.y}, z=${currentPosition.z}`,
                     );
+                    const lookDir = new THREE.Vector3();
+                    camera.getWorldDirection(lookDir);
+                    console.log(
+                        `Looking direction: x=${lookDir.x}, y=${lookDir.y}, z=${lookDir.z}`,
+                    );
                     break;
                 case "KeyT":
                     dispatch({type: 'SET_SCOREBOARD_VISIBLE', payload: true});


### PR DESCRIPTION
## Summary
- log the player's look direction when pressing **J**

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685400fc95bc8329af1aba203198cfbe