### PR TITLE
Add developer panel models prop

### DIFF
--- a/client/next-js/app/matches/[id]/game/page.tsx
+++ b/client/next-js/app/matches/[id]/game/page.tsx
@@ -13,6 +13,7 @@ import { useWS } from "@/hooks/useWS";
 import { useInterface } from "@/context/inteface";
 import { Game } from "@/components/game";
 import { Loading } from "@/components/loading";
+import { DeveloperPanel } from "@/components/DeveloperPanel";
 
 THREE.Cache.enabled = true;
 
@@ -148,12 +149,15 @@ export default function GamePage() {
   }
 
   return (
-    <Game
-      character={character}
-      matchId={params?.id}
-      models={preloadedData.models}
-      sounds={preloadedData.sounds}
-      textures={preloadedData.textures}
-    />
+    <>
+      <Game
+        character={character}
+        matchId={params?.id}
+        models={preloadedData.models}
+        sounds={preloadedData.sounds}
+        textures={preloadedData.textures}
+      />
+      <DeveloperPanel models={preloadedData.models} />
+    </>
   );
 }

--- a/client/next-js/components/DeveloperPanel.tsx
+++ b/client/next-js/components/DeveloperPanel.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+
+interface DeveloperPanelProps {
+  models?: Record<string, any>;
+}
+
+export const DeveloperPanel = ({ models = {} }: DeveloperPanelProps) => {
+  const [modelList, setModelList] = useState<string[]>([]);
+  const [scale, setScale] = useState(0.4);
+  const [model, setModel] = useState("");
+
+  useEffect(() => {
+    if (models && Object.keys(models).length) {
+      setModelList(
+        Object.keys(models).filter((key) => !key.endsWith("_animations")),
+      );
+    } else {
+      fetch("/api/models")
+        .then((res) => res.json())
+        .then((data) => setModelList(data.models || []))
+        .catch(() => {});
+    }
+  }, [models]);
+
+  useEffect(() => {
+    window.dispatchEvent(
+      new CustomEvent("DEV_SCALE_CHANGE", { detail: { scale } }),
+    );
+  }, [scale]);
+
+  useEffect(() => {
+    if (model) {
+      window.dispatchEvent(
+        new CustomEvent("DEV_MODEL_CHANGE", { detail: { model } }),
+      );
+    }
+  }, [model]);
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: 10,
+        right: 10,
+        background: "rgba(0,0,0,0.7)",
+        padding: "10px",
+        zIndex: 1000,
+        color: "white",
+      }}
+    >
+      <h4 className="mb-2 font-bold">Developer Panel</h4>
+      <div className="mb-2">
+        <label className="mr-2" htmlFor="dev-scale-slider">
+          Scale
+        </label>
+        <input
+          id="dev-scale-slider"
+          max="2"
+          min="0.1"
+          step="0.1"
+          type="range"
+          value={scale}
+          onChange={(e) => setScale(parseFloat(e.target.value))}
+        />
+        <span className="ml-2">{scale.toFixed(1)}</span>
+      </div>
+      <div>
+        <label className="mr-2" htmlFor="dev-model-select">
+          Model
+        </label>
+        <select
+          id="dev-model-select"
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+        >
+          <option value="">select</option>
+          {modelList.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+};

--- a/client/next-js/pages/api/models.ts
+++ b/client/next-js/pages/api/models.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs';
+import path from 'path';
+
+const MODELS_DIR = path.join(process.cwd(), 'public', 'models');
+
+function collect(dir: string, base = ''): string[] {
+  return fs.readdirSync(dir).flatMap((item) => {
+    const p = path.join(dir, item);
+    const rel = path.join(base, item);
+    if (fs.statSync(p).isDirectory()) {
+      return collect(p, rel);
+    }
+    if (item.endsWith('.glb') || item.endsWith('.fbx')) {
+      return [rel.replace(/\\/g, '/')];
+    }
+    return [];
+  });
+}
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const models = collect(MODELS_DIR);
+  res.status(200).json({ models });
+}


### PR DESCRIPTION
## Summary
- pass `models` prop to `DeveloperPanel` in game page so it can use preloaded models
- update `DeveloperPanel` to accept models via props and display those options
- associate labels with controls to satisfy linting

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685411c5e5f08329a7b8259e84e98df0