### PR TITLE
Add leveling and XP bar

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -155,7 +155,9 @@ export function Game({models, sounds, textures, matchId, character}) {
         const animations = models["character_animations"];
 
         let hp = MAX_HP,
-            mana = 100;
+            mana = 100,
+            points = 0,
+            level = 1;
         let actions = [];
         let playerMixers = [];
         let settings;
@@ -246,12 +248,12 @@ export function Game({models, sounds, textures, matchId, character}) {
 
         // Function to update the HP bar width
         function updateHPBar() {
-            dispatchEvent('self-update', { hp, mana });
+            dispatchEvent('self-update', { hp, mana, points, level });
         }
 
         // Function to update the Mana bar width
         function updateManaBar() {
-            dispatchEvent('self-update', { hp, mana });
+            dispatchEvent('self-update', { hp, mana, points, level });
         }
 
         function dispatchTargetUpdate() {
@@ -2401,6 +2403,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                     deaths: 0,
                     assists: 0,
                     points: 0,
+                    level: 1,
                     actions: {
                         idle: idleAction,
                         walk: walkAction,
@@ -2436,6 +2439,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                 playerData.deaths = message.deaths;
                 playerData.assists = message.assists;
                 playerData.points = message.points;
+                playerData.level = message.level;
                 playerData.buffs = message.buffs;
                 playerData.hp = message.hp;
                 playerData.mana = message.mana;
@@ -2841,6 +2845,8 @@ export function Game({models, sounds, textures, matchId, character}) {
                         } else {
                             hp = player.hp;
                             mana = player.mana;
+                            points = player.points;
+                            level = player.level;
                             updateHPBar();
                             updateManaBar();
                             dispatch({type: 'SET_BUFFS', payload: player.buffs || []});
@@ -2858,6 +2864,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                         kills: p.kills,
                         deaths: p.deaths,
                         points: p.points,
+                        level: p.level,
                     }));
                     dispatch({type: 'SET_SCOREBOARD_DATA', payload: boardData});
 

--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -4,6 +4,7 @@ import {Chat} from "../parts/Chat";
 import {Coins} from "../parts/Coins";
 import {Scoreboard} from "../parts/Scoreboard";
 import {Buffs} from "../parts/Buffs";
+import {ExperienceBar} from "../parts/ExperienceBar";
 import {Progress} from "@heroui/react";
 
 import {useInterface} from "@/context/inteface";
@@ -19,7 +20,7 @@ export const Interface = () => {
         state: { character },
     } = useInterface() as { state: { character: { name?: string } | null } };
     const [target, setTarget] = useState<{id:number, hp:number, mana:number, address:string, classType?:string}|null>(null);
-    const [selfStats, setSelfStats] = useState<{hp:number, mana:number}>({hp: MAX_HP, mana: 100});
+    const [selfStats, setSelfStats] = useState<{hp:number, mana:number, points:number, level:number}>({hp: MAX_HP, mana: 100, points: 0, level: 1});
 
     useEffect(() => {
         const handler = (e: CustomEvent) => {
@@ -33,7 +34,12 @@ export const Interface = () => {
         const handler = (e: CustomEvent) => {
             if (!e.detail) return;
             setSelfStats(prev => {
-                if (prev.hp === e.detail.hp && prev.mana === e.detail.mana) {
+                if (
+                    prev.hp === e.detail.hp &&
+                    prev.mana === e.detail.mana &&
+                    prev.points === e.detail.points &&
+                    prev.level === e.detail.level
+                ) {
                     return prev;
                 }
                 return e.detail;
@@ -105,6 +111,7 @@ export const Interface = () => {
             <Buffs />
             <SkillBar/>
             <CastBar/>
+            <ExperienceBar />
             <Chat />
         </div>
     )

--- a/client/next-js/components/parts/ExperienceBar.jsx
+++ b/client/next-js/components/parts/ExperienceBar.jsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+import { Progress } from "@heroui/react";
+import { XP_PER_LEVEL } from "@/consts";
+
+export const ExperienceBar = () => {
+    const [xp, setXp] = useState(0);
+    const [level, setLevel] = useState(1);
+
+    useEffect(() => {
+        const handler = (e) => {
+            if (!e.detail) return;
+            if (typeof e.detail.points === 'number') setXp(e.detail.points);
+            if (typeof e.detail.level === 'number') setLevel(e.detail.level);
+        };
+        window.addEventListener('self-update', handler);
+        return () => window.removeEventListener('self-update', handler);
+    }, []);
+
+    const progress = ((xp % XP_PER_LEVEL) / XP_PER_LEVEL) * 100;
+
+    return (
+        <div className="fixed bottom-2 left-1/2 transform -translate-x-1/2 w-full max-w-xl px-4 z-50 flex flex-col items-center">
+            <Progress id="xpBar" aria-label="XP" value={progress} color="warning" className="w-full" disableAnimation />
+            <div className="text-white text-sm font-semibold mt-1">Level {level}</div>
+        </div>
+    );
+};

--- a/client/next-js/consts/index.ts
+++ b/client/next-js/consts/index.ts
@@ -7,4 +7,6 @@ export const TREASURY_CAP_ID = process.env.NEXT_PUBLIC_TREASURY_CAP_ID;
 
 // Base health for players. Used for health bar calculations on both client and server
 export const MAX_HP = 120;
+// Amount of experience required for each level
+export const XP_PER_LEVEL = 1000;
 export { default as SPELL_COST } from './spellCosts.json';

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -6,10 +6,15 @@ const http = require('http');
 const UPDATE_MATCH_INTERVAL = 33;
 const MAX_HP = 120;
 const MAX_POINTS = 1000;
+const XP_PER_LEVEL = 1000;
 const MANA_REGEN_INTERVAL = 1000;
 const MANA_REGEN_AMOUNT = 1.3; // 30% faster mana regeneration
 const SPELL_COST = require('../client/next-js/consts/spellCosts.json');
 const ICEBALL_ICON = '/icons/spell_frostbolt.jpg';
+
+function updateLevel(player) {
+    player.level = Math.floor(player.points / XP_PER_LEVEL) + 1;
+}
 
 const RUNE_POSITIONS = [
     {x: -24.55270788467855, y: -2.2653316814013746, z: -29.33086680895419},
@@ -205,6 +210,7 @@ function createPlayer(address, classType) {
         deaths: 0,
         assists: 0,
         points: 0,
+        level: 1,
         hp: MAX_HP,
         mana: 100,
         chests: [],
@@ -308,7 +314,8 @@ function checkXpRunePickup(match, playerId) {
         const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
         if (dist < 1.5) {
             match.xpRunes.splice(i, 1);
-            player.points += 50;
+            player.points += 500;
+            updateLevel(player);
 
             broadcastToMatch(match.id, {
                 type: 'RUNE_PICKED',
@@ -350,7 +357,8 @@ function applyDamage(match, victimId, dealerId, damage, spellType) {
         victim.debuffs = [];
         if (attacker) {
             attacker.kills++;
-            attacker.points += 100;
+            attacker.points += 600;
+            updateLevel(attacker);
             broadcastToMatch(match.id, {
                 type: 'KILL',
                 killerId: dealerId,
@@ -493,7 +501,8 @@ ws.on('connection', (socket) => {
 
                 if (killerPlayer) {
                     killerPlayer.kills++;
-                    killerPlayer.points += 100;
+                    killerPlayer.points += 600;
+                    updateLevel(killerPlayer);
 
                     if (killerPlayer.points >= MAX_POINTS && !match.finished) {
                         finalizeMatch(match);


### PR DESCRIPTION
## Summary
- introduce XP_PER_LEVEL constant for clients and server
- award more XP for kills and XP runes
- track player level on server and client
- display experience bar with current level in interface

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_68550dd49b548329916f3a442cf54d42