### PR TITLE
Fix sphere cleanup bug and shorten range

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -626,7 +626,7 @@ export function Game({models, sounds, textures, matchId, character}) {
 
         // Maximum distance any sphere can travel
         // Use the same range as fireblast for consistency
-        const SPHERE_MAX_DISTANCE = FIREBLAST_RANGE;
+        const SPHERE_MAX_DISTANCE = FIREBLAST_RANGE / 2;
 
         const STEPS_PER_FRAME = 30;
 
@@ -634,7 +634,6 @@ export function Game({models, sounds, textures, matchId, character}) {
         const sphereMaterial = new THREE.MeshLambertMaterial({color: 0xdede8d});
 
         const spheres = [];
-        let sphereIdx = 0;
 
         // for (let i = 0; i < NUM_SPHERES; i++) {
         //
@@ -1408,7 +1407,7 @@ export function Game({models, sounds, textures, matchId, character}) {
             });
 
             // Store velocity and collider information for the fireball
-            spheres[sphereIdx] = {
+            spheres.push({
                 mesh: sphereMesh,
                 collider: new THREE.Sphere(
                     new THREE.Vector3().copy(sphereMesh.position),
@@ -1419,9 +1418,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                 type,
                 damage,
                 ownerId: myPlayerId,
-            };
-
-            sphereIdx = (sphereIdx + 1) % spheres.length;
+            });
         }
 
         function castSpellImpl(playerId, manaCost, duration, onUsage = () => {


### PR DESCRIPTION
## Summary
- halve maximum sphere travel distance
- store new spheres with `push` so previous spheres get cleaned up properly

## Testing
- `npx eslint components/game.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68590834a92c8329b44a7434bc5fa91c