### PR TITLE
Implement Paladin class and abilities

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -1,4 +1,4 @@
-import React, {useLayoutEffect, useRef, useState} from "react";
+import React, {useLayoutEffect, useRef, useState, useEffect} from "react";
 import {MAX_HP} from "../consts";
 import { SPELL_COST } from '../consts';
 import * as THREE from "three";
@@ -25,6 +25,10 @@ import castDarkball, { meta as darkballMeta } from '../skills/warlock/darkball';
 import castCorruption, { meta as corruptionMeta } from '../skills/warlock/corruption';
 import castImmolate, { meta as immolateMeta } from '../skills/warlock/immolate';
 import castChaosBolt, { meta as chaosBoltMeta } from '../skills/warlock/chaosBolt';
+import castLightStrike, { meta as lightStrikeMeta } from '../skills/paladin/lightStrike';
+import castStun, { meta as stunMeta } from '../skills/paladin/stun';
+import castPaladinHeal, { meta as paladinHealMeta } from '../skills/paladin/heal';
+import castLightWave, { meta as lightWaveMeta } from '../skills/paladin/lightWave';
 
 
 import {Interface} from "@/components/layout/Interface";
@@ -44,6 +48,10 @@ const SPELL_ICONS = {
     [corruptionMeta.id]: corruptionMeta.icon,
     [immolateMeta.id]: immolateMeta.icon,
     [chaosBoltMeta.id]: chaosBoltMeta.icon,
+    [lightStrikeMeta.id]: lightStrikeMeta.icon,
+    [stunMeta.id]: stunMeta.icon,
+    [paladinHealMeta.id]: paladinHealMeta.icon,
+    [lightWaveMeta.id]: lightWaveMeta.icon,
 };
 
 const SPELL_SCALES = {
@@ -115,7 +123,11 @@ function dispatchEvent(name = '', detail = {}) {
 export function Game({models, sounds, textures, matchId, character}) {
     const containerRef = useRef(null);
     const {refetch: refetchCoins} = useCoins();
-    const {dispatch} = useInterface();
+    const {state, dispatch} = useInterface();
+    const debuffsRef = useRef(state.debuffs);
+    useEffect(() => {
+        debuffsRef.current = state.debuffs;
+    }, [state.debuffs]);
     const {socket, sendToSocket} = useWS(matchId);
     const router = useRouter();
     const [isReadyToPlay, setIsReadyToPlay] = useState(false);
@@ -529,6 +541,10 @@ export function Game({models, sounds, textures, matchId, character}) {
             pyroblast: 6000,
             blink: 10000,
             heal: 0,
+            lightstrike: 0,
+            stun: 50000,
+            'paladin-heal': 30000,
+            lightwave: 120000,
         };
         const skillCooldownTimers = {};
 
@@ -619,6 +635,8 @@ export function Game({models, sounds, textures, matchId, character}) {
         const CHAOSBOLT_DAMAGE = FIREBALL_DAMAGE * 2;
         const ICEBALL_DAMAGE = 25;
         const DARKBALL_DAMAGE = 30;
+        const LIGHTSTRIKE_DAMAGE = 30;
+        const LIGHTWAVE_DAMAGE = 40;
 
         // Медленнее пускаем сферы как настоящие заклинания
         const MIN_SPHERE_IMPULSE = 6;
@@ -764,6 +782,91 @@ export function Game({models, sounds, textures, matchId, character}) {
         let jumpBlocked = false;
         const chatInputElement = document.getElementById("chat-input");
 
+        function handleKeyW() {
+            !isCasting && setAnimation("walk");
+        }
+        function handleKeyA() {
+            !isCasting && setAnimation("walk");
+        }
+        function handleKeyD() {
+            !isCasting && setAnimation("walk");
+        }
+        function handleKeyS() {
+            !isCasting && setAnimation("idle");
+        }
+        function handleKeyE() {
+            if (character?.name === 'warlock') castSpell('darkball');
+            else if (character?.name === 'paladin') castSpell('lightstrike');
+            else castSpell('fireball');
+        }
+        function handleKeyR() {
+            if (character?.name === 'warlock') castSpell('corruption');
+            else if (character?.name === 'paladin') castSpell('stun');
+            else castSpell('iceball');
+        }
+        function handleKeyF() {
+            if (character?.name === 'warlock') castSpell('chaosbolt');
+            else if (character?.name === 'paladin') castSpell('lightwave');
+            else castSpell('pyroblast');
+        }
+        function handleKeyG() {
+            leftMouseButtonClicked = true;
+        }
+        function handleKeyJ() {
+            const currentPosition = new THREE.Vector3();
+            playerCollider.getCenter(currentPosition);
+            console.log(
+                `Player position: x=${currentPosition.x}, y=${currentPosition.y}, z=${currentPosition.z}`,
+            );
+            const lookDir = new THREE.Vector3();
+            camera.getWorldDirection(lookDir);
+            console.log(
+                `Looking direction: x=${lookDir.x}, y=${lookDir.y}, z=${lookDir.z}`,
+            );
+        }
+        function handleKeyT() {
+            dispatch({type: 'SET_SCOREBOARD_VISIBLE', payload: true});
+        }
+        function handleSpace() {
+            if (playerOnFloor && !jumpBlocked) {
+                jumpBlocked = true;
+                const {mixer, actions} = players.get(myPlayerId);
+                const actionName = 'jump';
+                controlAction({
+                    action: actions[actionName],
+                    actionName,
+                    mixer: mixer,
+                    loop: THREE.LoopOnce,
+                    fadeIn: 0.1,
+                    reset: true,
+                    clampWhenFinished: true,
+                });
+                setTimeout(() => {
+                    playerVelocity.y = 6;
+                }, 150);
+            }
+        }
+        function handleKeyQ() {
+            if (character?.name === 'warlock') castSpell('immolate');
+            else if (character?.name === 'paladin') castSpell('paladin-heal');
+            else castSpell('fireblast');
+        }
+
+        const keyDownHandlers = {
+            KeyW: handleKeyW,
+            KeyA: handleKeyA,
+            KeyD: handleKeyD,
+            KeyS: handleKeyS,
+            KeyE: handleKeyE,
+            KeyR: handleKeyR,
+            KeyF: handleKeyF,
+            KeyG: handleKeyG,
+            KeyJ: handleKeyJ,
+            KeyT: handleKeyT,
+            Space: handleSpace,
+            KeyQ: handleKeyQ,
+        };
+
         document.addEventListener("keydown", (event) => {
             if (event.code === "Enter") {
                 if (!isChatActive) {
@@ -776,105 +879,41 @@ export function Game({models, sounds, textures, matchId, character}) {
 
             if (isChatActive) return;
 
-            if (!controlsEnabled) return;
+            if (!controlsEnabled || debuffsRef.current.some(d => d.type === 'stun')) return;
 
             keyStates[event.code] = true;
 
-            switch (event.code) {
-                // case "KeyR": // Blink Skill
-                //     castBlink();
-                //     break;
-                case "KeyW":
-                    // Start the walk animation immediately
-                    !isCasting && setAnimation("walk");
-                    break;
-                case "KeyA":
-                case "KeyD":
-                    // Optional: Handle strafing or side movement animations
-                    !isCasting && setAnimation("walk");
-                    break;
-                case "KeyS":
-                    // Optional: Set a backward movement animation
-                    !isCasting && setAnimation("idle");
-                    break;
-                case "KeyE":
-                    castSpell(character?.name === 'warlock' ? 'darkball' : 'fireball');
-                    break;
-                case "KeyR":
-                    castSpell(character?.name === 'warlock' ? 'corruption' : 'iceball');
-                    break;
-                case "KeyF":
-                    castSpell(character?.name === 'warlock' ? 'chaosbolt' : 'pyroblast');
-                    break;
-                case "KeyG":
-                    leftMouseButtonClicked = true;
-                    break;
-                case "KeyJ":
-                    const currentPosition = new THREE.Vector3();
-                    playerCollider.getCenter(currentPosition);
-                    console.log(
-                        `Player position: x=${currentPosition.x}, y=${currentPosition.y}, z=${currentPosition.z}`,
-                    );
-                    const lookDir = new THREE.Vector3();
-                    camera.getWorldDirection(lookDir);
-                    console.log(
-                        `Looking direction: x=${lookDir.x}, y=${lookDir.y}, z=${lookDir.z}`,
-                    );
-                    break;
-                case "KeyT":
-                    dispatch({type: 'SET_SCOREBOARD_VISIBLE', payload: true});
-                    break;
-                case "Space": // Press "Q" to cast shield
-                    // Space for jumping
-                    if (playerOnFloor && !jumpBlocked) {
-                        jumpBlocked = true;
-                        const {mixer, actions} = players.get(myPlayerId);
-                        const actionName = 'jump';
-                        controlAction({
-                            action: actions[actionName],
-                            actionName,
-                            mixer: mixer,
-                            loop: THREE.LoopOnce,
-                            fadeIn: 0.1,
-                            reset: true,
-                            clampWhenFinished: true,
-                            // onEnd: () => {
-                            //     console.log("Jump animation finished!");
-                            //     controlAction({action: idleAction, mixer: mixer, fadeIn: 0.5}); // Return to idle
-                            // }
-                        });
-                        setTimeout(() => {
-                            playerVelocity.y = 6; // Lower jump height
-                        }, 150);
-                    }
-                    break;
-                case "KeyQ":
-                    castSpell(character?.name === 'warlock' ? 'immolate' : 'fireblast');
-
-                    break;
-            }
+            const handler = keyDownHandlers[event.code];
+            if (handler) handler();
         });
+
+        function handleKeyUpG() {
+            leftMouseButtonClicked = false;
+        }
+        function handleKeyUpT() {
+            dispatch({type: 'SET_SCOREBOARD_VISIBLE', payload: false});
+        }
+        function handleKeyUpSpace() {
+            setTimeout(() => {
+                jumpBlocked = false;
+            }, 2000);
+        }
+
+        const keyUpHandlers = {
+            KeyG: handleKeyUpG,
+            KeyT: handleKeyUpT,
+            Space: handleKeyUpSpace,
+        };
 
         document.addEventListener("keyup", (event) => {
             if (isChatActive) return;
 
-            if (!controlsEnabled) return;
+            if (!controlsEnabled || debuffsRef.current.some(d => d.type === 'stun')) return;
 
             keyStates[event.code] = false;
 
-            switch (event.code) {
-                case "KeyG":
-                    leftMouseButtonClicked = false;
-                    break;
-                case "KeyT":
-                    dispatch({type: 'SET_SCOREBOARD_VISIBLE', payload: false});
-                    break;
-                case "Space": // Press "Q" to cast shield
-                    setTimeout(() => {
-                        jumpBlocked = false;
-                    }, 2000);
-                    break;
-            }
+            const handler = keyUpHandlers[event.code];
+            if (handler) handler();
 
             // // Check if no movement keys are active
             if (
@@ -903,7 +942,7 @@ export function Game({models, sounds, textures, matchId, character}) {
 
         // chatch even
         document.addEventListener("mousedown", (event) => {
-            if (!controlsEnabled) return;
+            if (!controlsEnabled || debuffsRef.current.some(d => d.type === 'stun')) return;
             if (event.button === 2) {
                 // Right mouse button
                 handleRightClick();
@@ -923,6 +962,7 @@ export function Game({models, sounds, textures, matchId, character}) {
 
         // block mouse
         containerRef.current.addEventListener("mousedown", () => {
+            if (debuffsRef.current.some(d => d.type === 'stun')) return;
             document.body.requestPointerLock();
             mouseTime = performance.now();
 
@@ -1339,6 +1379,52 @@ export function Game({models, sounds, textures, matchId, character}) {
                         damage: CHAOSBOLT_DAMAGE,
                     });
                     break;
+                case "lightstrike":
+                    castLightStrike({
+                        playerId,
+                        castSpellImpl,
+                        igniteHands,
+                        castSphere,
+                        fireballMesh,
+                        sounds,
+                        damage: LIGHTSTRIKE_DAMAGE,
+                    });
+                    break;
+                case "stun":
+                    castStun({
+                        playerId,
+                        globalSkillCooldown,
+                        isCasting,
+                        mana,
+                        getTargetPlayer,
+                        dispatch,
+                        sendToSocket,
+                        activateGlobalCooldown,
+                        startSkillCooldown,
+                        sounds,
+                    });
+                    break;
+                case "paladin-heal":
+                    castPaladinHeal({
+                        playerId,
+                        castSpellImpl,
+                        mana,
+                        getTargetPlayer,
+                        dispatch,
+                        sendToSocket,
+                        sounds,
+                    });
+                    break;
+                case "lightwave":
+                    castLightWave({
+                        playerId,
+                        globalSkillCooldown,
+                        isCasting,
+                        sendToSocket,
+                        activateGlobalCooldown,
+                        startSkillCooldown,
+                    });
+                    break;
             }
         }
 
@@ -1682,7 +1768,7 @@ export function Game({models, sounds, textures, matchId, character}) {
 
         function controls(deltaTime) {
             if (isChatActive) return;
-            if (!controlsEnabled) return;
+            if (!controlsEnabled || debuffsRef.current.some(d => d.type === 'stun')) return;
             const model = players.get(myPlayerId).model;
             // Adjust walking and running speed
             const baseWalkSpeed = 7.2; // Increased running speed by 20%
@@ -2087,6 +2173,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                 setTimeout(() => (movementSpeedModifier = 1), duration);
             }
         }
+
 
 
         function toggleShieldOnPlayer(id, visible) {
@@ -2717,6 +2804,27 @@ export function Game({models, sounds, textures, matchId, character}) {
                         case "pyroblast":
                             igniteHands(message.id, 1000);
                             castSphereOtherUser(message.payload, message.id);
+                            break;
+                        case "lightstrike":
+                            igniteHands(message.id, 500);
+                            castSphereOtherUser(message.payload, message.id);
+                            break;
+                        case "paladin-heal":
+                            if (message.payload.targetId === myPlayerId) {
+                                dispatch({ type: "SEND_CHAT_MESSAGE", payload: "You are healed!" });
+                            }
+                            break;
+                        case "lightwave":
+                            if (message.id !== myPlayerId) {
+                                const caster = players.get(message.id);
+                                if (caster) {
+                                    const myPos = players.get(myPlayerId)?.model.position.clone();
+                                    const casterPos = caster.model.position.clone();
+                                    if (myPos && casterPos && myPos.distanceTo(casterPos) < FIREBLAST_RANGE) {
+                                        takeDamage(LIGHTWAVE_DAMAGE, message.id, 'lightwave');
+                                    }
+                                }
+                            }
                             break;
                     }
 

--- a/client/next-js/components/parts/SkillBar.jsx
+++ b/client/next-js/components/parts/SkillBar.jsx
@@ -3,6 +3,7 @@ import {useInterface} from '@/context/inteface';
 import './SkillBar.css';
 import * as mageSkills from '../../skills/mage';
 import * as warlockSkills from '../../skills/warlock';
+import * as paladinSkills from '../../skills/paladin';
 
 const DEFAULT_SKILLS = [
     mageSkills.fireball,
@@ -18,9 +19,18 @@ const WARLOCK_SKILLS = [
     warlockSkills.chaosbolt,
 ];
 
+const PALADIN_SKILLS = [
+    paladinSkills.lightstrike,
+    paladinSkills.stun,
+    paladinSkills.paladinHeal,
+    paladinSkills.lightwave,
+];
+
 export const SkillBar = () => {
     const {state: {character}} = useInterface();
-    const skills = character?.name === 'warlock' ? WARLOCK_SKILLS : DEFAULT_SKILLS;
+    let skills = DEFAULT_SKILLS;
+    if (character?.name === 'warlock') skills = WARLOCK_SKILLS;
+    else if (character?.name === 'paladin') skills = PALADIN_SKILLS;
 
     const [cooldowns, setCooldowns] = useState({});
     const [pressed, setPressed] = useState({});

--- a/client/next-js/consts/classes.ts
+++ b/client/next-js/consts/classes.ts
@@ -1,4 +1,5 @@
 export const CLASS_ICONS: Record<string, string> = {
   mage: '/icons/mage.png',
   warlock: '/icons/warlock.webp',
+  paladin: '/icons/shield.png',
 };

--- a/client/next-js/consts/spellCosts.json
+++ b/client/next-js/consts/spellCosts.json
@@ -9,5 +9,9 @@
   "blink": 35,
   "heal": 35,
   "pyroblast": 70,
-  "chaosbolt": 70
+  "chaosbolt": 70,
+  "lightstrike": 20,
+  "stun": 0,
+  "paladin-heal": 50,
+  "lightwave": 0
 }

--- a/client/next-js/skills/paladin/heal.js
+++ b/client/next-js/skills/paladin/heal.js
@@ -1,0 +1,25 @@
+import { SPELL_COST } from '../../consts';
+
+export const meta = { id: 'paladin-heal', key: 'Q', icon: '/icons/shield.png' };
+
+export default function castPaladinHeal({ playerId, castSpellImpl, mana, getTargetPlayer, dispatch, sendToSocket, sounds }) {
+  if (mana < SPELL_COST['paladin-heal']) {
+    if (sounds?.noMana) {
+      sounds.noMana.currentTime = 0;
+      sounds.noMana.volume = 0.5;
+      sounds.noMana.play();
+    }
+    return;
+  }
+  const targetId = getTargetPlayer() || playerId;
+  castSpellImpl(
+    playerId,
+    SPELL_COST['paladin-heal'],
+    2000,
+    () => sendToSocket({ type: 'CAST_SPELL', payload: { type: 'paladin-heal', targetId } }),
+    sounds.spellCast,
+    sounds.heal,
+    meta.id,
+    false
+  );
+}

--- a/client/next-js/skills/paladin/index.js
+++ b/client/next-js/skills/paladin/index.js
@@ -1,0 +1,4 @@
+export { meta as lightstrike } from './lightStrike';
+export { meta as stun } from './stun';
+export { meta as paladinHeal } from './heal';
+export { meta as lightwave } from './lightWave';

--- a/client/next-js/skills/paladin/lightStrike.js
+++ b/client/next-js/skills/paladin/lightStrike.js
@@ -1,0 +1,17 @@
+import { SPELL_COST } from '../../consts';
+
+export const meta = { id: 'lightstrike', key: 'E', icon: '/icons/shield.png' };
+
+export default function castLightStrike({ playerId, castSpellImpl, igniteHands, castSphere, fireballMesh, sounds, damage }) {
+  igniteHands(playerId, 500);
+  castSpellImpl(
+    playerId,
+    SPELL_COST['lightstrike'],
+    0,
+    (model) => castSphere(model, fireballMesh.clone(), meta.id, damage),
+    sounds.fireballCast,
+    sounds.fireball,
+    meta.id,
+    true
+  );
+}

--- a/client/next-js/skills/paladin/lightWave.js
+++ b/client/next-js/skills/paladin/lightWave.js
@@ -1,0 +1,10 @@
+import { SPELL_COST } from '../../consts';
+
+export const meta = { id: 'lightwave', key: 'F', icon: '/icons/shield.png' };
+
+export default function castLightWave({ playerId, globalSkillCooldown, isCasting, sendToSocket, activateGlobalCooldown, startSkillCooldown }) {
+  if (globalSkillCooldown || isCasting) return;
+  sendToSocket({ type: 'CAST_SPELL', payload: { type: 'lightwave' } });
+  activateGlobalCooldown();
+  startSkillCooldown('lightwave');
+}

--- a/client/next-js/skills/paladin/stun.js
+++ b/client/next-js/skills/paladin/stun.js
@@ -1,0 +1,24 @@
+import { SPELL_COST } from '../../consts';
+
+export const meta = { id: 'stun', key: 'R', icon: '/icons/shield.png' };
+
+export default function castStun({ playerId, globalSkillCooldown, isCasting, mana, getTargetPlayer, dispatch, sendToSocket, activateGlobalCooldown, startSkillCooldown, sounds }) {
+  if (globalSkillCooldown || isCasting) return;
+  if (mana < SPELL_COST['stun']) {
+    if (sounds?.noMana) {
+      sounds.noMana.currentTime = 0;
+      sounds.noMana.volume = 0.5;
+      sounds.noMana.play();
+    }
+    return;
+  }
+  const targetId = getTargetPlayer();
+  if (!targetId) {
+    dispatch({ type: 'SEND_CHAT_MESSAGE', payload: `No target for stun!` });
+    sounds?.noTarget?.play?.();
+    return;
+  }
+  sendToSocket({ type: 'CAST_SPELL', payload: { type: 'stun', targetId } });
+  activateGlobalCooldown();
+  startSkillCooldown('stun');
+}

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -669,6 +669,12 @@ ws.on('connection', (socket) => {
                         if (message.payload.type === 'heal') {
                             player.hp = Math.min(MAX_HP, player.hp + 50);
                         }
+                        if (message.payload.type === 'paladin-heal') {
+                            const target = match.players.get(message.payload.targetId || id);
+                            if (target) {
+                                target.hp = Math.min(MAX_HP, target.hp + 50);
+                            }
+                        }
 
                         if (['immolate'].includes(message.payload.type)) {
                             broadcastToMatch(match.id, {
@@ -678,7 +684,7 @@ ws.on('connection', (socket) => {
                             });
                         }
                         
-                        if (['fireball', 'darkball', 'corruption', 'chaosbolt', 'iceball', 'shield', 'pyroblast', 'fireblast'].includes(message.payload.type)) {
+                        if (['fireball', 'darkball', 'corruption', 'chaosbolt', 'iceball', 'shield', 'pyroblast', 'fireblast', 'lightstrike', 'lightwave', 'stun', 'paladin-heal'].includes(message.payload.type)) {
                             broadcastToMatch(match.id, {
                                 type: 'CAST_SPELL',
                                 payload: message.payload,
@@ -712,6 +718,17 @@ ws.on('connection', (socket) => {
                                     nextTick: Date.now() + 1000,
                                     ticks: 5,
                                     icon: '/icons/spell_immolation.jpg',
+                                });
+                            }
+                        }
+                        if (message.payload.type === 'stun' && message.payload.targetId) {
+                            const target = match.players.get(message.payload.targetId);
+                            if (target) {
+                                target.debuffs = target.debuffs || [];
+                                target.debuffs.push({
+                                    type: 'stun',
+                                    expires: Date.now() + 3000,
+                                    icon: '/icons/shield.png'
                                 });
                             }
                         }


### PR DESCRIPTION
## Summary
- introduce Paladin skill set
- support paladin icons and spell costs
- wire new skills into client game logic and skill bar
- broadcast paladin spells on the server
- refactor client key handlers and track stun debuff from server

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*

------
https://chatgpt.com/codex/tasks/task_e_68590bbda1a883298f76552310c90402