### PR TITLE
Add skip navigation to profile form

### DIFF
--- a/client/next-js/components/profile-form.tsx
+++ b/client/next-js/components/profile-form.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Input } from "@heroui/input";
 import { Button } from "@heroui/react";
+import { useRouter } from "next/navigation";
 
 import { useTransaction } from "@/hooks";
 
@@ -12,6 +13,7 @@ export interface ProfileFormProps {
 export function ProfileForm({ onCreated }: ProfileFormProps) {
   const [nickname, setNickname] = useState("");
   const { createProfile } = useTransaction();
+  const router = useRouter();
 
   const handleCreate = async () => {
     if (!nickname) return;
@@ -30,6 +32,7 @@ export function ProfileForm({ onCreated }: ProfileFormProps) {
       <Button color="primary" isDisabled={!nickname} onPress={handleCreate}>
         Create Profile
       </Button>
+      <Button variant="light" onPress={() => router.push("/matches")}>Skip</Button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow skipping profile creation

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859294f2a2c8329b3a38722a3e4983b