### PR TITLE
Add per-skill autofocus option

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -54,6 +54,21 @@ const SPELL_ICONS = {
     [lightWaveMeta.id]: lightWaveMeta.icon,
 };
 
+const SPELL_META = {
+    [fireballMeta.id]: fireballMeta,
+    [iceballMeta.id]: iceballMeta,
+    [fireblastMeta.id]: fireblastMeta,
+    [pyroblastMeta.id]: pyroblastMeta,
+    [darkballMeta.id]: darkballMeta,
+    [corruptionMeta.id]: corruptionMeta,
+    [immolateMeta.id]: immolateMeta,
+    [chaosBoltMeta.id]: chaosBoltMeta,
+    [lightStrikeMeta.id]: lightStrikeMeta,
+    [stunMeta.id]: stunMeta,
+    [paladinHealMeta.id]: paladinHealMeta,
+    [lightWaveMeta.id]: lightWaveMeta,
+};
+
 const SPELL_SCALES = {
     fireball: 1.8,
     iceball: 1.8,
@@ -1233,7 +1248,8 @@ export function Game({models, sounds, textures, matchId, character}) {
 
         function castSpell(spellType, playerId = myPlayerId) {
             dispatchEvent('skill-use', { skill: spellType });
-            if (!isFocused) {
+            const meta = SPELL_META[spellType];
+            if (!isFocused && meta?.autoFocus !== false) {
                 handleRightClick();
             }
 

--- a/client/next-js/skills/paladin/lightStrike.js
+++ b/client/next-js/skills/paladin/lightStrike.js
@@ -4,6 +4,7 @@ export const meta = {
   id: 'lightstrike',
   key: 'E',
   icon: '/icons/classes/paladin/crusaderstrike.jpg',
+  autoFocus: false,
 };
 
 export default function castLightStrike({ playerId, castSpellImpl, igniteHands, castSphere, fireballMesh, sounds, damage }) {


### PR DESCRIPTION
## Summary
- let skills decide whether to auto-focus the target
- disable auto-focus for the paladin's Light Strike skill

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint-plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_6859786af2fc83299490dfeb5b3a087e