### PR TITLE
Add paladin lightstrike melee

### DIFF
--- a/client/next-js/skills/paladin/lightStrike.js
+++ b/client/next-js/skills/paladin/lightStrike.js
@@ -1,21 +1,12 @@
-import { SPELL_COST } from '../../consts';
-
 export const meta = {
   id: 'lightstrike',
   key: 'E',
   icon: '/icons/classes/paladin/crusaderstrike.jpg',
 };
 
-export default function castLightStrike({ playerId, castSpellImpl, igniteHands, castSphere, fireballMesh, sounds, damage }) {
-  igniteHands(playerId, 500);
-  castSpellImpl(
-    playerId,
-    SPELL_COST['lightstrike'],
-    0,
-    (model) => castSphere(model, fireballMesh.clone(), meta.id, damage),
-    sounds.fireballCast,
-    sounds.fireball,
-    meta.id,
-    true
-  );
+export default function castLightStrike({ globalSkillCooldown, isCasting, sendToSocket, activateGlobalCooldown, startSkillCooldown }) {
+  if (globalSkillCooldown || isCasting) return;
+  sendToSocket({ type: 'CAST_SPELL', payload: { type: 'lightstrike' } });
+  activateGlobalCooldown();
+  startSkillCooldown('lightstrike');
 }


### PR DESCRIPTION
## Summary
- migrate paladin sword attack into the existing lightstrike ability
- remove the old slash skill and update paladin skill bar
- send lightstrike spell over the network and animate sword swing
- apply damage in a cone using lightstrike constants

## Testing
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859782f99d483299130e72ae3079729