### PR TITLE
Fix import for newer Three.js

### DIFF
--- a/client/next-js/three/Fire.js
+++ b/client/next-js/three/Fire.js
@@ -8,7 +8,7 @@ import {
 	NearestFilter,
 	NoToneMapping,
 	OrthographicCamera,
-	PlaneBufferGeometry,
+       PlaneGeometry,
 	RGBAFormat,
 	Scene,
 	ShaderMaterial,
@@ -177,7 +177,7 @@ var Fire = function ( geometry, options ) {
 	this.orthoCamera = new OrthographicCamera( textureWidth / - 2, textureWidth / 2, textureHeight / 2, textureHeight / - 2, 1, 2 );
 	this.orthoCamera.position.z = 1;
 
-	this.fieldGeometry = new PlaneBufferGeometry( textureWidth, textureHeight );
+       this.fieldGeometry = new PlaneGeometry( textureWidth, textureHeight );
 
 	this.internalSource = new DataTexture( this.sourceData, textureWidth, textureHeight, RGBAFormat );
 


### PR DESCRIPTION
## Summary
- update Fire.js to import PlaneGeometry instead of removed PlaneBufferGeometry
- use PlaneGeometry when constructing field geometry

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685a55d3847c8329877dbbde7da4125f