### PR TITLE
Fix Fire class invocation

### DIFF
--- a/client/next-js/three/Fire.js
+++ b/client/next-js/three/Fire.js
@@ -21,9 +21,10 @@ import {
  *
  */
 
-var Fire = function ( geometry, options ) {
+class Fire extends Mesh {
+       constructor( geometry, options ) {
 
-	Mesh.call( this, geometry );
+               super( geometry );
 
 	this.type = 'Fire';
 
@@ -507,13 +508,12 @@ var Fire = function ( geometry, options ) {
 
 		this.restoreRenderState( renderer );
 
-	};
+       };
 
-};
+       }
+}
 
 
-Fire.prototype = Object.create( Mesh.prototype );
-Fire.prototype.constructor = Fire;
 
 Fire.SourceShader = {
 


### PR DESCRIPTION
## Summary
- update Fire.js to use ES6 class syntax and call super()

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a579331488329b28a5868997d2abb