### PR TITLE
Add in-game pause menu

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -159,9 +159,13 @@ export function Game({models, sounds, textures, matchId, character}) {
     const {refetch: refetchCoins} = useCoins();
     const {state, dispatch} = useInterface();
     const debuffsRef = useRef(state.debuffs);
+    const menuVisibleRef = useRef(state.menuVisible);
     useEffect(() => {
         debuffsRef.current = state.debuffs;
     }, [state.debuffs]);
+    useEffect(() => {
+        menuVisibleRef.current = state.menuVisible;
+    }, [state.menuVisible]);
     const {socket, sendToSocket} = useWS(matchId);
     const router = useRouter();
     const [isReadyToPlay, setIsReadyToPlay] = useState(false);
@@ -917,6 +921,9 @@ export function Game({models, sounds, textures, matchId, character}) {
             else if (className === 'paladin') castSpell('paladin-heal');
             else castSpell('frostnova');
         }
+        function handleEscape() {
+            dispatch({type: 'SET_MENU_VISIBLE', payload: !menuVisibleRef.current});
+        }
 
         const keyDownHandlers = {
             KeyW: handleKeyW,
@@ -936,6 +943,10 @@ export function Game({models, sounds, textures, matchId, character}) {
         };
 
         document.addEventListener("keydown", (event) => {
+            if (event.code === "Escape") {
+                handleEscape();
+                return;
+            }
             if (event.code === "Enter") {
                 if (!isChatActive) {
                     chatInputElement.focus();
@@ -947,7 +958,7 @@ export function Game({models, sounds, textures, matchId, character}) {
 
             if (isChatActive) return;
 
-            if (!controlsEnabled || debuffsRef.current.some(d => d.type === 'stun')) return;
+            if (!controlsEnabled || debuffsRef.current.some(d => d.type === 'stun') || menuVisibleRef.current) return;
 
             keyStates[event.code] = true;
 
@@ -976,7 +987,7 @@ export function Game({models, sounds, textures, matchId, character}) {
         document.addEventListener("keyup", (event) => {
             if (isChatActive) return;
 
-            if (!controlsEnabled || debuffsRef.current.some(d => d.type === 'stun')) return;
+            if (!controlsEnabled || debuffsRef.current.some(d => d.type === 'stun') || menuVisibleRef.current) return;
 
             keyStates[event.code] = false;
 

--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -3,6 +3,7 @@ import {CastBar} from "../parts/CastBar";
 import {Chat} from "../parts/Chat";
 import {Coins} from "../parts/Coins";
 import {Scoreboard} from "../parts/Scoreboard";
+import {GameMenu} from "../parts/Menu";
 import {Buffs} from "../parts/Buffs";
 import {ExperienceBar} from "../parts/ExperienceBar";
 import {Progress} from "@heroui/react";
@@ -108,6 +109,7 @@ export const Interface = () => {
 
 
             <Scoreboard />
+            <GameMenu />
             <Buffs />
             <SkillBar/>
             <CastBar/>

--- a/client/next-js/components/parts/Menu.css
+++ b/client/next-js/components/parts/Menu.css
@@ -1,0 +1,24 @@
+.menu-overlay {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: rgba(0, 0, 0, 0.8);
+    padding: 20px;
+    border-radius: 10px;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    min-width: 220px;
+    color: #fff;
+}
+
+.menu-button {
+    padding: 10px;
+    border: none;
+    border-radius: 5px;
+    background-color: #ffffff;
+    color: #000;
+    cursor: pointer;
+}

--- a/client/next-js/components/parts/Menu.jsx
+++ b/client/next-js/components/parts/Menu.jsx
@@ -1,0 +1,21 @@
+import { useInterface } from "../../context/inteface";
+import { useRouter } from "next/navigation";
+import "./Menu.css";
+
+export const GameMenu = () => {
+    const { state: { menuVisible }, dispatch } = useInterface();
+    const router = useRouter();
+
+    if (!menuVisible) return null;
+
+    const closeMenu = () => dispatch({ type: 'SET_MENU_VISIBLE', payload: false });
+
+    return (
+        <div className="menu-overlay">
+            <button className="menu-button">Graphics</button>
+            <button className="menu-button">General Settings</button>
+            <button className="menu-button" onClick={() => router.push('/play')}>Exit Game</button>
+            <button className="menu-button" onClick={closeMenu}>Return to Game</button>
+        </div>
+    );
+};

--- a/client/next-js/context/inteface.jsx
+++ b/client/next-js/context/inteface.jsx
@@ -7,6 +7,7 @@ export const initInterfaceState = {
     character: null,
     scoreboardData: [],
     scoreboardVisible: false,
+    menuVisible: false,
     buffs: [],
     debuffs: [],
 };
@@ -28,6 +29,9 @@ export const interfaceReducer = (state, action) => {
         }
         case 'SET_SCOREBOARD_VISIBLE': {
             return {...state, scoreboardVisible: action.payload};
+        }
+        case 'SET_MENU_VISIBLE': {
+            return {...state, menuVisible: action.payload};
         }
         case 'SET_BUFFS': {
             return {...state, buffs: action.payload};


### PR DESCRIPTION
## Summary
- add menuVisible state to interface context
- show a pause menu with Graphics, Settings, Exit Game, and Return to Game
- hide/show pause menu with ESC key

## Testing
- `npm run lint` *(fails: ESLint couldn't find dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685a5b2e31e88329b0864df25c94b6e6