### PR TITLE
Lower rune spawn height

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -2755,6 +2755,8 @@ export function Game({models, sounds, textures, matchId, character}) {
             const rune = SkeletonUtils.clone(base);
             rune.position.set(data.position.x, data.position.y, data.position.z);
             rune.scale.multiplyScalar(0.2);
+            // lower the rune slightly so it sits closer to the ground
+            rune.position.y -= 0.2;
             rune.userData.type = data.type;
 
             rune.traverse((child) => {


### PR DESCRIPTION
## Summary
- adjust rune creation logic so runes sit closer to the ground

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*
- `npm test` in server *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_685a5b64156883298297d9d459e4e653