### PR TITLE
Increase mana pool, adjust paladin heal

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -1,5 +1,5 @@
 import React, {useLayoutEffect, useRef, useState, useEffect} from "react";
-import {MAX_HP} from "../consts";
+import {MAX_HP, MAX_MANA} from "../consts";
 import { SPELL_COST } from '../consts';
 import * as THREE from "three";
 import { Fire } from "../three/Fire";
@@ -205,7 +205,7 @@ export function Game({models, sounds, textures, matchId, character}) {
         const animations = models["character_animations"];
 
         let hp = MAX_HP,
-            mana = 100,
+            mana = MAX_MANA,
             points = 0,
             level = 1;
         let actions = [];
@@ -585,7 +585,7 @@ export function Game({models, sounds, textures, matchId, character}) {
             heal: 0,
             lightstrike: 1000,
             stun: 50000,
-            'paladin-heal': 30000,
+            'paladin-heal': 20000,
             lightwave: 120000,
             frostnova: 15000,
             'hand-of-freedom': 15000,
@@ -1491,8 +1491,6 @@ export function Game({models, sounds, textures, matchId, character}) {
                         playerId,
                         castSpellImpl,
                         mana,
-                        getTargetPlayer,
-                        dispatch,
                         sendToSocket,
                         sounds,
                     });
@@ -3104,7 +3102,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                             }
                             break;
                         case "paladin-heal":
-                            if (message.payload.targetId === myPlayerId) {
+                            if (message.id === myPlayerId) {
                                 dispatch({ type: "SEND_CHAT_MESSAGE", payload: "You are healed!" });
                             }
                             break;

--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -14,14 +14,14 @@ import {CLASS_ICONS} from "@/consts/classes";
 import './Interface.css';
 import Image from "next/image";
 import React, {useEffect, useState} from "react";
-import {MAX_HP} from "../../consts";
+import {MAX_HP, MAX_MANA} from "../../consts";
 
 export const Interface = () => {
     const {
         state: { character },
     } = useInterface() as { state: { character: { name?: string } | null } };
     const [target, setTarget] = useState<{id:number, hp:number, mana:number, address:string, classType?:string}|null>(null);
-    const [selfStats, setSelfStats] = useState<{hp:number, mana:number, points:number, level:number}>({hp: MAX_HP, mana: 100, points: 0, level: 1});
+    const [selfStats, setSelfStats] = useState<{hp:number, mana:number, points:number, level:number}>({hp: MAX_HP, mana: MAX_MANA, points: 0, level: 1});
 
     useEffect(() => {
         const handler = (e: CustomEvent) => {
@@ -62,7 +62,7 @@ export const Interface = () => {
                     <p className="text-medium font-semibold">HP: {Math.round((selfStats.hp / MAX_HP) * 100)}</p>
                     <Progress id="hpBar" aria-label="HP" value={Math.round((selfStats.hp / MAX_HP) * 100)} color="secondary" disableAnimation />
                     <p className="text-medium font-semibold">Mana: {Math.round(selfStats.mana)}</p>
-                    <Progress id="manaBar" aria-label="Mana" value={Math.round(selfStats.mana)} color="primary" disableAnimation />
+                    <Progress id="manaBar" aria-label="Mana" value={Math.round((selfStats.mana / MAX_MANA) * 100)} color="primary" disableAnimation />
                 </div>
             </div>
 
@@ -78,7 +78,7 @@ export const Interface = () => {
                         <p className="text-medium font-semibold">HP: {Math.round((target.hp / MAX_HP) * 100)}</p>
                         <Progress id="targetHpBar" aria-label="Target HP" value={Math.round((target.hp / MAX_HP) * 100)} color="secondary" className="mb-1 w-40" disableAnimation />
                         <p className="text-medium font-semibold">Mana: {Math.round(target.mana)}</p>
-                        <Progress id="targetManaBar" aria-label="Target Mana" value={Math.round(target.mana)} color="primary" className="w-40" disableAnimation />
+                        <Progress id="targetManaBar" aria-label="Target Mana" value={Math.round((target.mana / MAX_MANA) * 100)} color="primary" className="w-40" disableAnimation />
                     </div>
                 </div>
             )}

--- a/client/next-js/consts/index.ts
+++ b/client/next-js/consts/index.ts
@@ -7,6 +7,7 @@ export const TREASURY_CAP_ID = process.env.NEXT_PUBLIC_TREASURY_CAP_ID;
 
 // Base health for players. Used for health bar calculations on both client and server
 export const MAX_HP = 120;
+export const MAX_MANA = 130;
 // Amount of experience required for each level
 export const XP_PER_LEVEL = 1000;
 export { default as SPELL_COST } from './spellCosts.json';

--- a/client/next-js/skills/paladin/heal.js
+++ b/client/next-js/skills/paladin/heal.js
@@ -6,7 +6,7 @@ export const meta = {
   icon: '/icons/classes/paladin/searinglight.jpg',
 };
 
-export default function castPaladinHeal({ playerId, castSpellImpl, mana, getTargetPlayer, dispatch, sendToSocket, sounds }) {
+export default function castPaladinHeal({ playerId, castSpellImpl, mana, sendToSocket, sounds }) {
   if (mana < SPELL_COST['paladin-heal']) {
     if (sounds?.noMana) {
       sounds.noMana.currentTime = 0;
@@ -15,12 +15,11 @@ export default function castPaladinHeal({ playerId, castSpellImpl, mana, getTarg
     }
     return;
   }
-  const targetId = getTargetPlayer() || playerId;
   castSpellImpl(
     playerId,
     SPELL_COST['paladin-heal'],
     2000,
-    () => sendToSocket({ type: 'CAST_SPELL', payload: { type: 'paladin-heal', targetId } }),
+    () => sendToSocket({ type: 'CAST_SPELL', payload: { type: 'paladin-heal' } }),
     sounds.spellCast,
     sounds.heal,
     meta.id,

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -5,6 +5,7 @@ const http = require('http');
 
 const UPDATE_MATCH_INTERVAL = 33;
 const MAX_HP = 120;
+const MAX_MANA = 130;
 const MAX_POINTS = 10000;
 const XP_PER_LEVEL = 1000;
 const MANA_REGEN_INTERVAL = 1000;
@@ -215,7 +216,7 @@ function createPlayer(address, classType) {
         points: 0,
         level: 1,
         hp: MAX_HP,
-        mana: 100,
+        mana: MAX_MANA,
         chests: [],
         address,
         classType
@@ -275,7 +276,7 @@ function checkRunePickup(match, playerId) {
                     player.hp = Math.min(MAX_HP, player.hp + 100);
                     break;
                 case 'mana':
-                    player.mana = Math.min(100, player.mana + 100);
+                    player.mana = Math.min(MAX_MANA, player.mana + 100);
                     break;
                 case 'damage':
                     player.buffs.push({
@@ -378,7 +379,7 @@ function applyDamage(match, victimId, dealerId, damage, spellType) {
         victim.spawn_point = spawn;
         victim.rotation = { y: spawn.yaw || 0 };
         victim.hp = MAX_HP;
-        victim.mana = 100;
+        victim.mana = MAX_MANA;
         victim.animationAction = 'idle';
 
         broadcastToMatch(match.id, {
@@ -428,8 +429,8 @@ ws.on('connection', (socket) => {
         const now = Date.now();
         for (const match of matches.values()) {
             match.players.forEach((player, pid) => {
-                if (player.mana < 100) {
-                    player.mana = Math.min(100, player.mana + MANA_REGEN_AMOUNT);
+                if (player.mana < MAX_MANA) {
+                    player.mana = Math.min(MAX_MANA, player.mana + MANA_REGEN_AMOUNT);
                 }
                 if (player.buffs.length) {
                     player.buffs = player.buffs.filter(b => b.expires > now);
@@ -677,10 +678,7 @@ ws.on('connection', (socket) => {
                             player.hp = Math.min(MAX_HP, player.hp + 50);
                         }
                         if (message.payload.type === 'paladin-heal') {
-                            const target = match.players.get(message.payload.targetId || id);
-                            if (target) {
-                                target.hp = Math.min(MAX_HP, target.hp + 50);
-                            }
+                            player.hp = Math.min(MAX_HP, player.hp + 50);
                         }
 
                         if (['immolate'].includes(message.payload.type)) {
@@ -830,7 +828,7 @@ ws.on('connection', (socket) => {
                     const p = match.players.get(id);
                     if (p) {
                         p.hp = MAX_HP;
-                        p.mana = 100;
+                        p.mana = MAX_MANA;
                         p.buffs = [];
                         p.debuffs = [];
                         broadcastToMatch(match.id, {


### PR DESCRIPTION
## Summary
- increase max mana to 130 on client and server
- adjust mana display to use new max
- paladin heal now only heals the caster and has a 20s cooldown

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a7312b67c8329acceb87f69c3310c