### PR TITLE
Implement soulbound profiles

### DIFF
--- a/server/server.cjs
+++ b/server/server.cjs
@@ -2,6 +2,7 @@ const WebSocket = require('ws');
 const http = require('http');
 // const { mintChest } = require('./sui.cjs');
 // const { mintCoins, mintItemWithOptions } = require('./sui.cjs');
+const { createProfile } = require('./sui.cjs');
 
 const UPDATE_MATCH_INTERVAL = 33;
 const MAX_HP = 120;
@@ -556,6 +557,12 @@ ws.on('connection', (socket) => {
                         matchId: summaryId,
                         summary,
                     }));
+                }
+                break;
+
+            case 'CREATE_PROFILE':
+                if (message.address && message.nickname) {
+                    createProfile(message.address, message.nickname);
                 }
                 break;
 

--- a/server/sui.cjs
+++ b/server/sui.cjs
@@ -136,8 +136,25 @@ async function mintItemWithOptions(recipientAddress, itemType, opts = {}) {
         const { signature, bytes: signed } = await keypair.signTransaction(bytes);
         await client.executeTransactionBlock({ transactionBlock: signed, signature });
     } catch (error) {
-        console.error('mintItemWithOptions failed:', error);
+    console.error('mintItemWithOptions failed:', error);
+}
+
+async function createProfile(recipientAddress, nickname) {
+    try {
+        const tx = new Transaction();
+        tx.moveCall({
+            target: `${PACKAGE_ID}::profile::mint_profile`,
+            arguments: [tx.pure.string(nickname), tx.pure.address(recipientAddress)],
+        });
+        tx.setGasBudget(10000000);
+        tx.setSender(keypair.toSuiAddress());
+        const bytes = await tx.build({ client });
+        const { signature, bytes: signed } = await keypair.signTransaction(bytes);
+        await client.executeTransactionBlock({ transactionBlock: signed, signature });
+    } catch (error) {
+        console.error('createProfile failed:', error);
     }
+}
 }
 
 module.exports = {
@@ -145,4 +162,5 @@ module.exports = {
     mintChest,
     mintItem,
     mintItemWithOptions,
+    createProfile,
 };

--- a/smart-contracts/meta_war/sources/profile.move
+++ b/smart-contracts/meta_war/sources/profile.move
@@ -15,6 +15,20 @@ module meta_war::profile {
         Profile { id: object::new(ctx), nickname, rank: 0 }
     }
 
+    /// Mint a new profile and transfer it to the recipient. The resulting
+    /// `Profile` object does not have the `store` ability and therefore cannot
+    /// be transferred outside of this module, effectively making it soul bound
+    /// to the recipient.
+    #[allow(lint(self_transfer))]
+    public entry fun mint_profile(
+        nickname: vector<u8>,
+        recipient: address,
+        ctx: &mut TxContext,
+    ) {
+        let prof = create(nickname, ctx);
+        transfer::transfer(prof, recipient);
+    }
+
     /// Update nickname
     public fun set_nickname(profile: &mut Profile, nickname: vector<u8>) {
         profile.nickname = nickname


### PR DESCRIPTION
## Summary
- make profile object soulbound by minting and transferring it in-module
- expose `mint_profile` Move entry function
- add `createProfile` transaction util on the server
- handle `CREATE_PROFILE` messages in websocket server

## Testing
- `npm test` *(fails: no test specified)*
- `which sui` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a81ed246c8329b4ec6c37de8c08c6