### PR TITLE
Add character field to players

### DIFF
--- a/client/next-js/app/matches/[id]/game/page.tsx
+++ b/client/next-js/app/matches/[id]/game/page.tsx
@@ -42,6 +42,8 @@ export default function GamePage() {
 
   const models = [
     { id: "zone", path: "zone.glb" },
+    { id: "bolvar", path: "skins/bolvar.glb" },
+    { id: "vampir", path: "skins/vampir.glb" },
     {
       id: "character",
       path: character?.name === "paladin" ? "skins/bolvar.glb" : "skins/vampir.glb",

--- a/client/next-js/app/matches/[id]/page.tsx
+++ b/client/next-js/app/matches/[id]/page.tsx
@@ -87,7 +87,8 @@ export default function MatchesPage() {
 
     useEffect(() => {
         if (classType && !joined) {
-            sendToSocket({type: 'JOIN_MATCH', classType});
+            const charModel = classType === 'paladin' ? 'bolvar' : 'vampir';
+            sendToSocket({type: 'JOIN_MATCH', classType, character: charModel});
             sendToSocket({type: 'GET_MATCH'});
             setJoined(true);
         }
@@ -95,7 +96,8 @@ export default function MatchesPage() {
 
     const handleReady = () => {
         if (!joined && classType) {
-            sendToSocket({type: 'JOIN_MATCH', classType});
+            const charModel = classType === 'paladin' ? 'bolvar' : 'vampir';
+            sendToSocket({type: 'JOIN_MATCH', classType, character: charModel});
         }
         dispatch({type: 'SET_CHARACTER', payload: {name: classType.toLowerCase(), skin}});
         router.push(`/matches/${params?.id}/game`);

--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -2791,9 +2791,10 @@ export function Game({models, sounds, textures, matchId, character}) {
             return actions;
         }
 
-        function createPlayer(id, name = "", address = "", classType = "") {
-            if (models['character']) {
-                const player = SkeletonUtils.clone(models['character']);
+        function createPlayer(id, name = "", address = "", classType = "", characterModel = "vampir") {
+            const baseModel = models[characterModel] || models['character'];
+            if (baseModel) {
+                const player = SkeletonUtils.clone(baseModel);
                 player.position.set(...USER_DEFAULT_POSITION);
 
                 player.scale.set(currentScale, currentScale, currentScale);
@@ -2841,6 +2842,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                     buffs: [],
                     address,
                     classType,
+                    character: characterModel,
                 });
                 if (actions.idle) actions.idle.play();
                 playerMixers.push(mixer);   // массив всех чужих миксеров
@@ -2871,6 +2873,9 @@ export function Game({models, sounds, textures, matchId, character}) {
                 playerData.address = message.address || playerData.address;
                 if (message.classType) {
                     playerData.classType = message.classType;
+                }
+                if (message.character) {
+                    playerData.character = message.character;
                 }
 
                 const action = actions?.[message.animationAction];
@@ -3093,8 +3098,9 @@ export function Game({models, sounds, textures, matchId, character}) {
                             const id = Number(pid);
                             if (players.has(id)) {
                                 players.get(id).classType = pdata.classType;
+                                players.get(id).character = pdata.character;
                             } else {
-                                players.set(id, { classType: pdata.classType });
+                                players.set(id, { classType: pdata.classType, character: pdata.character });
                             }
                         });
                     }
@@ -3428,8 +3434,10 @@ export function Game({models, sounds, textures, matchId, character}) {
                     console.log("MATCH_READY: ", message);
                     myPlayerId = message.myPlayerId;
                     message.players.forEach((playerId) => {
-                        const cls = players.get(Number(playerId))?.classType || "";
-                        createPlayer(Number(playerId), String(playerId), String(playerId), cls);
+                        const p = players.get(Number(playerId));
+                        const cls = p?.classType || "";
+                        const charModel = p?.character || (cls === 'paladin' ? 'bolvar' : 'vampir');
+                        createPlayer(Number(playerId), String(playerId), String(playerId), cls, charModel);
                     })
                     startCountdown();
                     break;

--- a/client/next-js/types/index.ts
+++ b/client/next-js/types/index.ts
@@ -52,6 +52,7 @@ export interface Championship {
 export interface PlayerData {
   address: string;
   classType: string;
+  character?: string;
 }
 
 export interface MatchDetail {

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -202,8 +202,15 @@ function broadcastMatchesToWaitingClients() {
     }
 }
 
-function createPlayer(address, classType) {
+const CLASS_MODELS = {
+    paladin: 'bolvar',
+    mage: 'vampir',
+    warlock: 'vampir',
+};
+
+function createPlayer(address, classType, character) {
     const spawn = randomSpawnPoint();
+    const charName = character || CLASS_MODELS[classType] || 'vampir';
     return {
         position: {...spawn},
         spawn_point: spawn,
@@ -220,7 +227,8 @@ function createPlayer(address, classType) {
         mana: MAX_MANA,
         chests: [],
         address,
-        classType
+        classType,
+        character: charName,
     };
 }
 
@@ -582,7 +590,8 @@ ws.on('connection', (socket) => {
                     break;
                 }
 
-                const newPlayer = createPlayer(message.address, message.classType || message.character?.name);
+                const char = typeof message.character === 'string' ? message.character : null;
+                const newPlayer = createPlayer(message.address, message.classType, char);
                 matchToJoin.players.set(id, newPlayer);
                 broadcastToMatch(matchToJoin.id, {
                     type: 'PLAYER_RESPAWN',


### PR DESCRIPTION
## Summary
- allow players to specify the model they use
- preload all character models
- spawn models according to each player's character
- include character info in match join messages
- keep character in player data on the server

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint-plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_685aa623ad208329be4a80e845f5b17b