### PR TITLE
Darken skills when insufficient mana

### DIFF
--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -111,7 +111,7 @@ export const Interface = () => {
             <Scoreboard />
             <GameMenu />
             <Buffs />
-            <SkillBar/>
+            <SkillBar mana={selfStats.mana}/>
             <CastBar/>
             <ExperienceBar />
             <Chat />

--- a/client/next-js/components/parts/SkillBar.css
+++ b/client/next-js/components/parts/SkillBar.css
@@ -26,6 +26,10 @@
     transition-duration: 0.1s;
 }
 
+.skill-button.no-mana .skill-icon {
+    filter: brightness(0.4) grayscale(50%);
+}
+
 .skill-icon {
     width: 80%;
     height: 80%;

--- a/client/next-js/components/parts/SkillBar.jsx
+++ b/client/next-js/components/parts/SkillBar.jsx
@@ -1,5 +1,6 @@
 import {useEffect, useState} from 'react';
 import {useInterface} from '@/context/inteface';
+import { SPELL_COST } from '@/consts';
 import './SkillBar.css';
 import * as mageSkills from '../../skills/mage';
 import * as warlockSkills from '../../skills/warlock';
@@ -32,7 +33,7 @@ const PALADIN_SKILLS = [
     paladinSkills.divineSpeed,
 ];
 
-export const SkillBar = () => {
+export const SkillBar = ({ mana = 0 }) => {
     const {state: {character}} = useInterface();
     let skills = DEFAULT_SKILLS;
     if (character?.name === 'warlock') skills = WARLOCK_SKILLS;
@@ -93,8 +94,9 @@ export const SkillBar = () => {
                     const remaining = data.end - Date.now();
                     text = Math.ceil(remaining / 1000);
                 }
+                const insufficientMana = mana < (SPELL_COST[skill.id] || 0);
                 return (
-                    <div className={`skill-button${pressed[skill.id] ? ' pressed' : ''}`} key={skill.id}>
+                    <div className={`skill-button${pressed[skill.id] ? ' pressed' : ''}${insufficientMana ? ' no-mana' : ''}`} key={skill.id}>
                         <div className="skill-icon" style={{backgroundImage: `url('${skill.icon}')`}}></div>
                         {data && (
                             <div className="cooldown-overlay">


### PR DESCRIPTION
## Summary
- color skill icons darker when mana is insufficient
- forward mana value from `Interface` to `SkillBar`

## Testing
- `npm run lint` *(fails: eslint-plugin-react not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aaa81f2448329a492fc22ffde41c5