### PR TITLE
Reduce darkball size and show fear icon

### DIFF
--- a/client/next-js/skills/warlock/fear.js
+++ b/client/next-js/skills/warlock/fear.js
@@ -1,5 +1,7 @@
 import { SPELL_COST } from '../../consts';
 
+const FEAR_CAST_TIME = 2000; // ms
+
 export const meta = { id: 'fear', key: '3', icon: '/icons/classes/warlock/possession.jpg' };
 
 export default function castFear({ playerId, castSpellImpl, mana, getTargetPlayer, dispatch, sendToSocket, sounds }) {
@@ -20,7 +22,7 @@ export default function castFear({ playerId, castSpellImpl, mana, getTargetPlaye
   castSpellImpl(
     playerId,
     SPELL_COST['fear'],
-    2000,
+    FEAR_CAST_TIME,
     () => sendToSocket({ type: 'CAST_SPELL', payload: { type: 'fear', targetId } }),
     sounds.spellCast,
     sounds.spellCast,


### PR DESCRIPTION
## Summary
- shrink darkball visuals by 30%
- add fear debuff sprite that appears above the affected player
- set fear cast time to 2 seconds

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_685aaf94d4108329bc89d54cd08a5360