### PR TITLE
Update rogue skill icons

### DIFF
--- a/client/next-js/skills/rogue/adrenalineRush.js
+++ b/client/next-js/skills/rogue/adrenalineRush.js
@@ -3,7 +3,7 @@ import { SPELL_COST } from '../../consts';
 export const meta = {
   id: 'adrenaline-rush',
   key: '2',
-  icon: '/icons/classes/paladin/divinestorm.jpg',
+  icon: '/icons/classes/rogue/adrenalinerush.jpg',
   autoFocus: false,
 };
 

--- a/client/next-js/skills/rogue/bloodStrike.js
+++ b/client/next-js/skills/rogue/bloodStrike.js
@@ -3,7 +3,7 @@ import { SPELL_COST } from '../../consts';
 export const meta = {
   id: 'blood-strike',
   key: 'E',
-  icon: '/icons/classes/paladin/crusaderstrike.jpg',
+  icon: '/icons/classes/rogue/sinister_strike.jpg',
   autoFocus: false,
 };
 

--- a/client/next-js/skills/rogue/eviscerate.js
+++ b/client/next-js/skills/rogue/eviscerate.js
@@ -3,7 +3,7 @@ import { SPELL_COST } from '../../consts';
 export const meta = {
   id: 'eviscerate',
   key: 'R',
-  icon: '/icons/classes/warrior/savageblow.jpg',
+  icon: '/icons/classes/rogue/eviscerate.jpg',
   autoFocus: false,
 };
 

--- a/client/next-js/skills/rogue/kidneyStrike.js
+++ b/client/next-js/skills/rogue/kidneyStrike.js
@@ -3,7 +3,7 @@ import { SPELL_COST } from '../../consts';
 export const meta = {
   id: 'kidney-strike',
   key: 'F',
-  icon: '/icons/classes/paladin/sealofmight.jpg',
+  icon: '/icons/classes/rogue/kidneyshot.jpg',
 };
 
 export default function castKidneyStrike({ playerId, globalSkillCooldown, isCasting, mana, getTargetPlayer, dispatch, sendToSocket, activateGlobalCooldown, startSkillCooldown, sounds }) {

--- a/client/next-js/skills/rogue/shadowLeap.js
+++ b/client/next-js/skills/rogue/shadowLeap.js
@@ -3,7 +3,7 @@ import { SPELL_COST } from '../../consts';
 export const meta = {
   id: 'shadow-leap',
   key: 'Q',
-  icon: '/icons/classes/mage/blink.jpg',
+  icon: '/icons/classes/rogue/shadowstep.jpg',
 };
 
 export default function castShadowLeap({ playerId, globalSkillCooldown, isCasting, mana, getTargetPlayer, dispatch, sendToSocket, activateGlobalCooldown, startSkillCooldown, sounds }) {

--- a/client/next-js/skills/rogue/sprint.js
+++ b/client/next-js/skills/rogue/sprint.js
@@ -3,7 +3,7 @@ import { SPELL_COST } from '../../consts';
 export const meta = {
   id: 'sprint',
   key: '3',
-  icon: '/icons/classes/paladin/speedoflight.jpg',
+  icon: '/icons/classes/rogue/sprint.jpg',
   autoFocus: false,
 };
 

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -804,7 +804,7 @@ ws.on('connection', (socket) => {
                                 target.debuffs.push({
                                     type: 'stun',
                                     expires: Date.now() + duration,
-                                    icon: '/icons/classes/paladin/sealofmight.jpg'
+                                    icon: '/icons/classes/rogue/kidneyshot.jpg'
                                 });
                                 player.comboPoints = 0;
                                 player.comboTarget = null;


### PR DESCRIPTION
## Summary
- switch rogue skill icons to correct images under `/public/icons/classes/rogue`
- use kidney shot icon for its stun debuff

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b1f4f3f6c832992c5c7f672d09528