### PR TITLE
Fix server.cjs syntax error

### DIFF
--- a/server/server.cjs
+++ b/server/server.cjs
@@ -857,7 +857,6 @@ ws.on('connection', (socket) => {
                             });
                         }
                     }
-                }
                 break;
 
             case 'TAKE_DAMAGE':


### PR DESCRIPTION
## Summary
- remove an extraneous closing brace to keep the `CAST_SPELL` case inside the switch

## Testing
- `node -c server/server.cjs`

------
https://chatgpt.com/codex/tasks/task_e_685b26578ecc83299c61fd957ea64e28