### PR TITLE
Move skill tracking to server

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -243,7 +243,9 @@ export function Game({models, sounds, textures, matchId, character}) {
         let hp = MAX_HP,
             mana = MAX_MANA,
             points = 0,
-            level = 1;
+            level = 1,
+            skillPoints = 1;
+        let learnedSkills = {};
         let actions = [];
         let playerMixers = [];
         let settings;
@@ -396,12 +398,12 @@ export function Game({models, sounds, textures, matchId, character}) {
 
         // Function to update the HP bar width
         function updateHPBar() {
-            dispatchEvent('self-update', { hp, mana, points, level });
+            dispatchEvent('self-update', { hp, mana, points, level, skillPoints, learnedSkills });
         }
 
         // Function to update the Mana bar width
         function updateManaBar() {
-            dispatchEvent('self-update', { hp, mana, points, level });
+            dispatchEvent('self-update', { hp, mana, points, level, skillPoints, learnedSkills });
         }
 
         function dispatchTargetUpdate() {
@@ -1362,6 +1364,9 @@ export function Game({models, sounds, textures, matchId, character}) {
 
 
         function castSpell(spellType, playerId = myPlayerId) {
+            if (!learnedSkills || !learnedSkills[spellType]) {
+                return;
+            }
             dispatchEvent('skill-use', { skill: spellType });
             const meta = SPELL_META[spellType];
             if (!isFocused && meta?.autoFocus !== false) {
@@ -3761,6 +3766,8 @@ export function Game({models, sounds, textures, matchId, character}) {
                             mana = player.mana;
                             points = player.points;
                             level = player.level;
+                            skillPoints = player.skillPoints || skillPoints;
+                            learnedSkills = player.learnedSkills || learnedSkills;
                             updateHPBar();
                             updateManaBar();
                             dispatch({type: 'SET_BUFFS', payload: player.buffs || []});

--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -21,7 +21,7 @@ export const Interface = () => {
         state: { character },
     } = useInterface() as { state: { character: { name?: string } | null } };
     const [target, setTarget] = useState<{id:number, hp:number, mana:number, address:string, classType?:string}|null>(null);
-    const [selfStats, setSelfStats] = useState<{hp:number, mana:number, points:number, level:number}>({hp: MAX_HP, mana: MAX_MANA, points: 0, level: 1});
+    const [selfStats, setSelfStats] = useState<{hp:number, mana:number, points:number, level:number, skillPoints:number, learnedSkills:Record<string, boolean>}>({hp: MAX_HP, mana: MAX_MANA, points: 0, level: 1, skillPoints:1, learnedSkills:{}});
 
     useEffect(() => {
         const handler = (e: CustomEvent) => {
@@ -39,7 +39,8 @@ export const Interface = () => {
                     prev.hp === e.detail.hp &&
                     prev.mana === e.detail.mana &&
                     prev.points === e.detail.points &&
-                    prev.level === e.detail.level
+                    prev.level === e.detail.level &&
+                    prev.skillPoints === e.detail.skillPoints
                 ) {
                     return prev;
                 }
@@ -111,7 +112,7 @@ export const Interface = () => {
             <Scoreboard />
             <GameMenu />
             <Buffs />
-            <SkillBar mana={selfStats.mana}/>
+            <SkillBar mana={selfStats.mana} level={selfStats.level} skillPoints={selfStats.skillPoints} learnedSkills={selfStats.learnedSkills}/>
             <CastBar/>
             <ExperienceBar />
             <Chat />

--- a/client/next-js/components/parts/SkillBar.css
+++ b/client/next-js/components/parts/SkillBar.css
@@ -62,3 +62,17 @@
     pointer-events: none;
     font-size: 14px;
 }
+
+.skill-button.locked .skill-icon {
+    filter: grayscale(100%) brightness(0.4);
+}
+
+.skill-triangle {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 0;
+    height: 0;
+    border-left: 12px solid transparent;
+    border-bottom: 12px solid gold;
+}


### PR DESCRIPTION
## Summary
- maintain skillPoints and learnedSkills for each player server-side
- require learned skills to cast spells
- send LEARN_SKILL message when using Shift+Key
- surface skill info through Interface and SkillBar

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685bc71565b08329b0d2a24b253e9b24