### PR TITLE
Fix rogue shadow leap logic

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -1686,6 +1686,11 @@ export function Game({models, sounds, textures, matchId, character}) {
                         activateGlobalCooldown,
                         startSkillCooldown,
                         sounds,
+                        players,
+                        teleportTo,
+                        playerCollider,
+                        worldOctree,
+                        FIREBLAST_RANGE,
                     });
                     break;
                 case "warbringer":

--- a/client/next-js/skills/rogue/shadowLeap.js
+++ b/client/next-js/skills/rogue/shadowLeap.js
@@ -1,3 +1,5 @@
+import * as THREE from 'three';
+import { Capsule } from 'three/examples/jsm/math/Capsule';
 import { SPELL_COST } from '../../consts';
 
 export const meta = {
@@ -6,7 +8,23 @@ export const meta = {
   icon: '/icons/classes/rogue/shadowstep.jpg',
 };
 
-export default function castShadowLeap({ playerId, globalSkillCooldown, isCasting, mana, getTargetPlayer, dispatch, sendToSocket, activateGlobalCooldown, startSkillCooldown, sounds }) {
+export default function castShadowLeap({
+  playerId,
+  globalSkillCooldown,
+  isCasting,
+  mana,
+  getTargetPlayer,
+  dispatch,
+  sendToSocket,
+  activateGlobalCooldown,
+  startSkillCooldown,
+  sounds,
+  players,
+  teleportTo,
+  playerCollider,
+  worldOctree,
+  FIREBLAST_RANGE,
+}) {
   if (globalSkillCooldown || isCasting) return;
   if (mana < SPELL_COST['shadow-leap']) {
     if (sounds?.noMana) {
@@ -22,6 +40,35 @@ export default function castShadowLeap({ playerId, globalSkillCooldown, isCastin
     sounds?.noTarget?.play?.();
     return;
   }
+
+  const target = players?.get(targetId)?.model;
+  const caster = players?.get(playerId)?.model;
+  if (!target || !caster) return;
+
+  const casterPos = new THREE.Vector3();
+  playerCollider.getCenter(casterPos);
+  const targetPos = target.position.clone();
+
+  const distance = casterPos.distanceTo(targetPos);
+  if (distance > FIREBLAST_RANGE) {
+    dispatch({ type: 'SEND_CHAT_MESSAGE', payload: `Target too far for shadow leap!` });
+    sounds?.noTarget?.play?.();
+    return;
+  }
+
+  const rotY = target.rotation.y || 0;
+  const BEHIND_DISTANCE = 1.5;
+  const backOffset = new THREE.Vector3(Math.sin(rotY), 0, Math.cos(rotY)).multiplyScalar(-BEHIND_DISTANCE);
+  const behind = targetPos.clone().add(backOffset);
+
+  const intersect = worldOctree?.capsuleIntersect(
+    new Capsule(behind, behind.clone().add(new THREE.Vector3(0, 0.75, 0)), 0.35),
+  );
+
+  if (!intersect) {
+    teleportTo(behind);
+  }
+
   sendToSocket({ type: 'CAST_SPELL', payload: { type: 'shadow-leap', targetId } });
   activateGlobalCooldown();
   startSkillCooldown('shadow-leap');


### PR DESCRIPTION
## Summary
- implement range checking and behind teleport for rogue's Shadow Leap skill
- pass required data to castShadowLeap in game loop

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685be90f33f88329aec0fc832f79e741