### PR TITLE
Change skill upgrade indicator to plus icon

### DIFF
--- a/client/next-js/components/parts/SkillBar.css
+++ b/client/next-js/components/parts/SkillBar.css
@@ -67,12 +67,13 @@
     filter: grayscale(100%) brightness(0.4);
 }
 
-.skill-triangle {
+.skill-plus {
     position: absolute;
-    top: 0;
-    right: 0;
-    width: 0;
-    height: 0;
-    border-left: 12px solid transparent;
-    border-bottom: 12px solid gold;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: gold;
+    font-size: 24px;
+    line-height: 1;
+    pointer-events: none;
 }

--- a/client/next-js/components/parts/SkillBar.jsx
+++ b/client/next-js/components/parts/SkillBar.jsx
@@ -157,7 +157,7 @@ export const SkillBar = ({ mana = 0, level = 1, skillPoints = 0, learnedSkills =
                 return (
                     <div className={`skill-button${pressed[skill.id] ? ' pressed' : ''}${insufficientMana ? ' no-mana' : ''}${locked ? ' locked' : ''}`} key={skill.id}>
                         <div className="skill-icon" style={{backgroundImage: `url('${skill.icon}')`}}></div>
-                        {locked && points > 0 && <div className="skill-triangle" />}
+                        {locked && points > 0 && <div className="skill-plus">+</div>}
                         {data && (
                             <div className="cooldown-overlay">
                                 {text}


### PR DESCRIPTION
## Summary
- replace the yellow triangle indicator with a yellow '+'
- style the new `skill-plus` overlay in the SkillBar

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*

------
https://chatgpt.com/codex/tasks/task_e_685bfd00427883299e1af27478612e4a