### PR TITLE
Add sound effects for warrior and rogue skills

### DIFF
--- a/client/next-js/app/matches/[id]/game/page.tsx
+++ b/client/next-js/app/matches/[id]/game/page.tsx
@@ -138,6 +138,8 @@ export default function GamePage() {
       damageRune: new Audio("/sounds/damage-rune.ogg"),
       sinisterStrike: new Audio("/sounds/sinister-strike.ogg"),
       mortalStrike: new Audio("/sounds/mortal-strike.ogg"),
+      charge: new Audio("/sounds/charge.ogg"),
+      shadowLeap: new Audio("/sounds/shadowleap.ogg"),
     };
 
     Promise.all([preloadModels(models), preloadTextures()]).then(

--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -3581,6 +3581,11 @@ export function Game({models, sounds, textures, matchId, character}) {
                             }
                             break;
                         case "shadow-leap":
+                            if (sounds.shadowLeap) {
+                                sounds.shadowLeap.currentTime = 0;
+                                sounds.shadowLeap.volume = 0.5;
+                                sounds.shadowLeap.play();
+                            }
                             break;
                         case "stun":
                             if (message.payload.targetId) {
@@ -3588,6 +3593,11 @@ export function Game({models, sounds, textures, matchId, character}) {
                             }
                             break;
                         case "warbringer":
+                            if (sounds.charge) {
+                                sounds.charge.currentTime = 0;
+                                sounds.charge.volume = 0.5;
+                                sounds.charge.play();
+                            }
                             break;
                         case "savage-blow":
                             if (message.id !== myPlayerId) {

--- a/client/next-js/skills/rogue/shadowLeap.js
+++ b/client/next-js/skills/rogue/shadowLeap.js
@@ -72,5 +72,9 @@ export default function castShadowLeap({
   sendToSocket({ type: 'CAST_SPELL', payload: { type: 'shadow-leap', targetId } });
   activateGlobalCooldown();
   startSkillCooldown('shadow-leap');
+  if (sounds?.shadowLeap) {
+    sounds.shadowLeap.volume = 0.5;
+    sounds.shadowLeap.play();
+  }
   return targetId;
 }

--- a/client/next-js/skills/warrior/warbringer.js
+++ b/client/next-js/skills/warrior/warbringer.js
@@ -77,8 +77,8 @@ export default function castWarbringer({
   sendToSocket({ type: 'CAST_SPELL', payload: { type: 'warbringer' } });
   activateGlobalCooldown();
   startSkillCooldown('warbringer');
-  if (sounds?.blink) {
-    sounds.blink.volume = 0.5;
-    sounds.blink.play();
+  if (sounds?.charge) {
+    sounds.charge.volume = 0.5;
+    sounds.charge.play();
   }
 }


### PR DESCRIPTION
## Summary
- add Charge and Shadow Leap audio files in the game preload step
- play Charge sound when casting Warbringer
- play Shadow Leap sound when rogue casts Shadow Leap
- trigger respective sounds for other players via network events

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_685bfe33723083299da7225017f4508b