### PR TITLE
Add target buffs display and energy label

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -421,7 +421,9 @@ export function Game({models, sounds, textures, matchId, character}) {
                 hp: p.hp,
                 mana: p.mana,
                 address: p.address || `Player ${targetedPlayerId}`,
-                classType: p.classType
+                classType: p.classType,
+                buffs: p.buffs || [],
+                debuffs: p.debuffs || [],
             });
         }
 
@@ -3205,6 +3207,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                 playerData.points = message.points;
                 playerData.level = message.level;
                 playerData.buffs = message.buffs;
+                playerData.debuffs = message.debuffs;
                 playerData.hp = message.hp;
                 playerData.mana = message.mana;
                 playerData.address = message.address || playerData.address;
@@ -3682,6 +3685,8 @@ export function Game({models, sounds, textures, matchId, character}) {
                         mana = message.mana;
                         updateHPBar();
                         updateManaBar();
+                        dispatch({type: 'SET_BUFFS', payload: message.buffs || []});
+                        dispatch({type: 'SET_DEBUFFS', payload: message.debuffs || []});
                         if (hp <= 0) {
                             // waiting for server respawn
                         }
@@ -3689,6 +3694,8 @@ export function Game({models, sounds, textures, matchId, character}) {
                         const p = players.get(message.playerId);
                         p.hp = message.hp;
                         p.mana = message.mana;
+                        p.buffs = message.buffs || [];
+                        p.debuffs = message.debuffs || [];
                         if (message.playerId === targetedPlayerId) {
                             dispatchTargetUpdate();
                         }

--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -20,7 +20,7 @@ export const Interface = () => {
     const {
         state: { character },
     } = useInterface() as { state: { character: { name?: string } | null } };
-    const [target, setTarget] = useState<{id:number, hp:number, mana:number, address:string, classType?:string}|null>(null);
+    const [target, setTarget] = useState<{id:number, hp:number, mana:number, address:string, classType?:string, buffs?:any[], debuffs?:any[]}|null>(null);
     const [selfStats, setSelfStats] = useState<{hp:number, mana:number, points:number, level:number, skillPoints:number, learnedSkills:Record<string, boolean>}>({hp: MAX_HP, mana: MAX_MANA, points: 0, level: 1, skillPoints:1, learnedSkills:{}});
 
     useEffect(() => {
@@ -78,10 +78,13 @@ export const Interface = () => {
                         <div id="targetAddress" className="target-address">{target.address}</div>
                         <p className="text-medium font-semibold">HP: {Math.round((target.hp / MAX_HP) * 100)}</p>
                         <Progress id="targetHpBar" aria-label="Target HP" value={Math.round((target.hp / MAX_HP) * 100)} color="secondary" className="mb-1 w-40" disableAnimation />
-                        <p className="text-medium font-semibold">Mana: {Math.round(target.mana)}</p>
-                        <Progress id="targetManaBar" aria-label="Target Mana" value={Math.round((target.mana / MAX_MANA) * 100)} color="primary" className="w-40" disableAnimation />
+                        <p className="text-medium font-semibold">{(target.classType === 'rogue' || target.classType === 'warrior') ? 'Energy' : 'Mana'}: {Math.round(target.mana)}</p>
+                        <Progress id="targetManaBar" aria-label={(target.classType === 'rogue' || target.classType === 'warrior') ? 'Target Energy' : 'Target Mana'} value={Math.round((target.mana / MAX_MANA) * 100)} color="primary" className="w-40" disableAnimation />
                     </div>
                 </div>
+            )}
+            {target && (
+                <Buffs buffs={target.buffs || []} debuffs={target.debuffs || []} className="target-buffs-container" />
             )}
 
             <div id="target" style={{

--- a/client/next-js/components/parts/Buffs.css
+++ b/client/next-js/components/parts/Buffs.css
@@ -46,3 +46,15 @@
     color: #fff;
     pointer-events: none;
 }
+
+.target-buffs-container {
+    position: absolute;
+    top: 100px;
+    left: 180px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    width: 140px;
+    pointer-events: none;
+    z-index: 1000;
+}

--- a/client/next-js/components/parts/Buffs.jsx
+++ b/client/next-js/components/parts/Buffs.jsx
@@ -2,16 +2,19 @@ import {useInterface} from '@/context/inteface';
 import {useEffect, useState} from 'react';
 import './Buffs.css';
 
-export const Buffs = () => {
+export const Buffs = ({buffs: propBuffs, debuffs: propDebuffs, className = 'buffs-container'}) => {
     const {state: {buffs = [], debuffs = []}} = useInterface();
     const [now, setNow] = useState(Date.now());
+
+    const finalBuffs = propBuffs !== undefined ? propBuffs : buffs;
+    const finalDebuffs = propDebuffs !== undefined ? propDebuffs : debuffs;
 
     useEffect(() => {
         const id = setInterval(() => setNow(Date.now()), 1000);
         return () => clearInterval(id);
     }, []);
 
-    if (!buffs.length && !debuffs.length) return null;
+    if (!finalBuffs.length && !finalDebuffs.length) return null;
 
     const formatTime = (ms) => {
         const total = Math.max(0, Math.ceil(ms / 1000));
@@ -45,9 +48,9 @@ export const Buffs = () => {
     };
 
     return (
-        <div className="buffs-container">
-            {buffs.map((b, idx) => renderIcon(b, idx, 'buff'))}
-            {debuffs.map((d, idx) => renderIcon(d, idx, 'debuff'))}
+        <div className={className}>
+            {finalBuffs.map((b, idx) => renderIcon(b, idx, 'buff'))}
+            {finalDebuffs.map((d, idx) => renderIcon(d, idx, 'debuff'))}
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- display energy instead of mana for rogue/warrior targets
- expose buff/debuff arrays to the interface
- show buffs below the target panel with countdown
- allow Buffs component to accept custom data

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c04056b148329be62c002283f9a4b