### PR TITLE
Adjust attack animation speeds

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -3125,6 +3125,10 @@ export function Game({models, sounds, textures, matchId, character}) {
                 attack360: get('attack_360'),
             };
 
+            // Speed up attack animations
+            if (actions.attack) actions.attack.timeScale *= 2;
+            if (actions.attack360) actions.attack360.timeScale *= 2;
+
             return actions;
         }
 


### PR DESCRIPTION
## Summary
- speed up `attack` and `attack_360` animations

## Testing
- `npm run lint` *(fails: Parsing error in `app/matches/[id]/page.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_685c0755156883298799b4facd9f8fd9