### PR TITLE
Fix classType missing in Interface

### DIFF
--- a/client/next-js/app/matches/[id]/page.tsx
+++ b/client/next-js/app/matches/[id]/page.tsx
@@ -105,7 +105,14 @@ export default function MatchesPage() {
             sendToSocket({type: 'JOIN_MATCH', classType, character: charModel});
             setSkin(charModel);
         }
-        dispatch({type: 'SET_CHARACTER', payload: {name: classType.toLowerCase(), skin}});
+        dispatch({
+            type: 'SET_CHARACTER',
+            payload: {
+                name: classType.toLowerCase(),
+                classType: classType.toLowerCase(),
+                skin,
+            },
+        });
         router.push(`/matches/${params?.id}/game`);
     };
 


### PR DESCRIPTION
## Summary
- pass `classType` when storing character state

## Testing
- `npm run lint` *(fails: ESLint couldn't find plugin `eslint-plugin-react`)*

------
https://chatgpt.com/codex/tasks/task_e_685c1248261c8329988787a624db338a