### PR TITLE
Fix typed character model path

### DIFF
--- a/client/next-js/app/matches/[id]/game/page.tsx
+++ b/client/next-js/app/matches/[id]/game/page.tsx
@@ -16,6 +16,12 @@ import { Game } from "@/components/game";
 import { Loading } from "@/components/loading";
 import { DeveloperPanel } from "@/components/DeveloperPanel";
 
+interface Character {
+  name?: string;
+  classType?: string;
+  skin?: string;
+}
+
 THREE.Cache.enabled = true;
 
 const dracoLoader = new DRACOLoader();
@@ -39,7 +45,11 @@ export default function GamePage() {
   });
   const {
     state: { character },
-  } = useInterface();
+  } = useInterface() as { state: { character: Character | null } };
+
+  const charSkin = character?.name
+    ? CLASS_MODELS[character.name as keyof typeof CLASS_MODELS] || "vampir"
+    : "vampir";
 
   const models = [
     { id: "zone", path: "zone.glb" },
@@ -48,7 +58,7 @@ export default function GamePage() {
     { id: "mad", path: "skins/mad.glb" },
     {
       id: "character",
-      path: `skins/${CLASS_MODELS[character?.name ?? ""] || "vampir"}.glb`,
+      path: `skins/${charSkin}.glb`,
     },
     { id: "heal-effect", path: "heal-effect.glb" },
     { id: "bottle_magic", path: "bottle_magic.glb" },


### PR DESCRIPTION
## Summary
- use a `Character` interface for context state
- cast `useInterface` return type for safe property access
- derive `charSkin` to resolve character model path

## Testing
- `npm run lint` *(fails: eslint-plugin-react not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c17a4efdc8329ad2d3d114c039ad5