### PR TITLE
Fix optional props for Buffs component

### DIFF
--- a/client/next-js/app/matches/[id]/page.tsx
+++ b/client/next-js/app/matches/[id]/page.tsx
@@ -195,3 +195,4 @@ export default function MatchesPage() {
             </div>
         </>
     );
+}

--- a/client/next-js/components/parts/Buffs.jsx
+++ b/client/next-js/components/parts/Buffs.jsx
@@ -2,7 +2,12 @@ import {useInterface} from '@/context/inteface';
 import {useEffect, useState} from 'react';
 import './Buffs.css';
 
-export const Buffs = ({buffs: propBuffs, debuffs: propDebuffs, className = 'buffs-container'}) => {
+/**
+ * @param {{buffs?: any[], debuffs?: any[], className?: string}} [props]
+ */
+export const Buffs = (
+    {buffs: propBuffs, debuffs: propDebuffs, className = 'buffs-container'} = {}
+) => {
     const {state: {buffs = [], debuffs = []}} = useInterface();
     const [now, setNow] = useState(Date.now());
 


### PR DESCRIPTION
## Summary
- allow `<Buffs>` to be used without props by adding default parameter and JSDoc comment
- close `MatchesPage` component with missing bracket

## Testing
- `npx eslint@8 -c .eslintrc.json . --ext .ts,.tsx`
- `npm run build` *(fails: Unknown network undefined)*

------
https://chatgpt.com/codex/tasks/task_e_685c2211c8fc8329892e327b06dd58af