### PR TITLE
Adjust damage display and skill icon sizes

### DIFF
--- a/client/next-js/components/layout/Interface.css
+++ b/client/next-js/components/layout/Interface.css
@@ -34,7 +34,7 @@
     padding: 2px 4px;
     border-radius: 3px;
     font-weight: 800;
-    font-size: 24px;
+    font-size: 32px;
     pointer-events: none;
     display: flex;
     align-items: center;
@@ -44,14 +44,14 @@
 
 
 .damage-icon {
-    width: 24px;
-    height: 24px;
+    width: 32px;
+    height: 32px;
 }
 
 
 #selfDamage .damage-icon {
-    width: 32px;
-    height: 32px;
+    width: 48px;
+    height: 48px;
 }
 
 .damage-label-container {
@@ -75,7 +75,7 @@
 }
 
 #selfDamage .damage-label {
-    font-size: 32px;
+    font-size: 48px;
 }
 
 #targetPanel {

--- a/client/next-js/components/parts/SkillBar.css
+++ b/client/next-js/components/parts/SkillBar.css
@@ -1,7 +1,7 @@
 
 .skill-button {
-    width: 50px;
-    height: 50px;
+    width: 64px;
+    height: 64px;
     background-color: #555;
     border: 2px solid #333;
     border-radius: 5px;
@@ -31,8 +31,8 @@
 }
 
 .skill-icon {
-    width: 80%;
-    height: 80%;
+    width: 90%;
+    height: 90%;
     background-size: cover;
     background-position: center;
 }
@@ -73,7 +73,7 @@
     left: 50%;
     transform: translate(-50%, -50%);
     color: gold;
-    font-size: 24px;
+    font-size: 30px;
     line-height: 1;
     pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- enlarge damage numbers and icons
- make skill buttons and icons larger

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin `eslint-plugin-react`)*

------
https://chatgpt.com/codex/tasks/task_e_685c570c7cb48329af4fb115eaa08f53