### PR TITLE
Fix combo-point buff disappearance

### DIFF
--- a/server/server.cjs
+++ b/server/server.cjs
@@ -361,7 +361,7 @@ function applyDamage(match, victimId, dealerId, damage, spellType) {
     if (attacker && attacker.buffs.length) {
         const now = Date.now();
         attacker.buffs.forEach(buff => {
-            if (buff.type === 'damage' && buff.expires > now) {
+            if (buff.type === 'damage' && (buff.expires === undefined || buff.expires > now)) {
                 if (typeof buff.percent === 'number') {
                     totalDamage += totalDamage * buff.percent;
                 } else if (typeof buff.bonus === 'number') {


### PR DESCRIPTION
## Summary
- ensure damage buffs without expiration remain active
- keep buffs without expiration in server tick

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test` in `client/next-js` (fails: Missing script: "test")


------
https://chatgpt.com/codex/tasks/task_e_685d6a9e13548329b9d8bcc30c3a20f0