### PR TITLE
Implement WebSocket rankings with summary

### DIFF
--- a/client/next-js/app/matches/[id]/summary/page.tsx
+++ b/client/next-js/app/matches/[id]/summary/page.tsx
@@ -1,77 +1,94 @@
 "use client";
 
-import {useWS} from "@/hooks/useWS";
-import {useEffect, useState} from "react";
-import {Table, TableHeader, TableColumn, TableBody, TableRow, TableCell, Button} from "@heroui/react";
-import {useParams, useRouter} from "next/navigation";
-import {Navbar} from "@/components/navbar";
+import { useEffect, useState } from "react";
+import {
+  Table,
+  TableHeader,
+  TableColumn,
+  TableBody,
+  TableRow,
+  TableCell,
+  Button,
+} from "@heroui/react";
+import { useParams, useRouter } from "next/navigation";
+
+import { useWS } from "@/hooks/useWS";
+import { Navbar } from "@/components/navbar";
 
 interface PlayerSummary {
-    id: number;
-    kills: number;
-    deaths: number;
-    reward: string;
-    coins: number;
-    item?: { class: string; skin: string } | null;
+  id: number;
+  kills: number;
+  deaths: number;
+  reward: string;
+  coins: number;
+  item?: { class: string; skin: string } | null;
+  rankDelta: number;
 }
 
 export default function MatchSummaryPage() {
-    const params = useParams();
-    const router = useRouter();
-    const {socket, sendToSocket} = useWS(params?.id);
-    const [summary, setSummary] = useState<PlayerSummary[]>([]);
+  const params = useParams();
+  const router = useRouter();
+  const { socket, sendToSocket } = useWS(params?.id);
+  const [summary, setSummary] = useState<PlayerSummary[]>([]);
 
-    useEffect(() => {
-        const handleMessage = (event: MessageEvent) => {
-            const message = JSON.parse(event.data);
-            switch (message.type) {
-                case "MATCH_SUMMARY":
-                    setSummary(message.summary);
-                    break;
-            }
-        };
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      const message = JSON.parse(event.data);
 
-        socket.addEventListener('message', handleMessage);
+      switch (message.type) {
+        case "MATCH_SUMMARY":
+          setSummary(message.summary);
+          break;
+      }
+    };
 
-        sendToSocket({type: 'GET_MATCH_SUMMARY', matchId: params?.id});
+    socket.addEventListener("message", handleMessage);
 
-        return () => {
-            socket.removeEventListener('message', handleMessage);
-        };
-    }, []);
+    sendToSocket({ type: "GET_MATCH_SUMMARY", matchId: params?.id });
 
-    const back = () => router.push('/matches');
+    return () => {
+      socket.removeEventListener("message", handleMessage);
+    };
+  }, []);
 
-    return (
-        <div className="h-full">
-            <Navbar/>
-            <div className="flex justify-center items-center">
-                <div className="max-w-[640px] min-w-[480px] flex gap-8 flex-col">
-                    <Table aria-label="Match summary">
-                    <TableHeader>
-                            <TableColumn>Player</TableColumn>
-                            <TableColumn>Kills</TableColumn>
-                            <TableColumn>Deaths</TableColumn>
-                            <TableColumn>Reward</TableColumn>
-                            <TableColumn>Coins</TableColumn>
-                            <TableColumn>Item</TableColumn>
-                        </TableHeader>
-                        <TableBody>
-                            {summary.map(p => (
-                                <TableRow key={p.id}>
-                                    <TableCell>{`Player ${p.id}`}</TableCell>
-                                    <TableCell>{p.kills}</TableCell>
-                                    <TableCell>{p.deaths}</TableCell>
-                                    <TableCell>{p.reward}</TableCell>
-                                    <TableCell>{p.coins}</TableCell>
-                                    <TableCell>{p.item ? `${p.item.skin} ${p.item.class}` : '-'}</TableCell>
-                                </TableRow>
-                            ))}
-                        </TableBody>
-                    </Table>
-                    <Button color="primary" onPress={back}>Back to matches</Button>
-                </div>
-            </div>
+  const back = () => router.push("/matches");
+
+  return (
+    <div className="h-full">
+      <Navbar />
+      <div className="flex justify-center items-center">
+        <div className="max-w-[640px] min-w-[480px] flex gap-8 flex-col">
+          <Table aria-label="Match summary">
+            <TableHeader>
+              <TableColumn>Player</TableColumn>
+              <TableColumn>Kills</TableColumn>
+              <TableColumn>Deaths</TableColumn>
+              <TableColumn>Reward</TableColumn>
+              <TableColumn>Coins</TableColumn>
+              <TableColumn>Item</TableColumn>
+              <TableColumn>Rank +/-</TableColumn>
+            </TableHeader>
+            <TableBody>
+              {summary.map((p) => (
+                <TableRow key={p.id}>
+                  <TableCell>{`Player ${p.id}`}</TableCell>
+                  <TableCell>{p.kills}</TableCell>
+                  <TableCell>{p.deaths}</TableCell>
+                  <TableCell>{p.reward}</TableCell>
+                  <TableCell>{p.coins}</TableCell>
+                  <TableCell>
+                    {p.item ? `${p.item.skin} ${p.item.class}` : "-"}
+                  </TableCell>
+                  <TableCell>{p.rankDelta}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+          <Button color="primary" onPress={back}>
+            Back to matches
+          </Button>
         </div>
-    );
+      </div>
+    </div>
+  );
 }

--- a/client/next-js/app/play/page.tsx
+++ b/client/next-js/app/play/page.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import Image from "next/image";
-import { Card, CardHeader } from "@heroui/react";
+import {
+  Card,
+  CardHeader,
+  Table,
+  TableHeader,
+  TableColumn,
+  TableBody,
+  TableRow,
+  TableCell,
+} from "@heroui/react";
 import { useRouter } from "next/navigation";
 import { useCurrentAccount } from "@mysten/dapp-kit";
 
@@ -9,11 +18,13 @@ import { Navbar } from "@/components/navbar";
 import { ConnectionButton } from "@/components/connection-button";
 import { ProfileForm } from "@/components/profile-form";
 import { useProfile } from "@/hooks";
+import { useRatings } from "@/hooks/useRatings";
 
 export default function MatchesPage() {
   const router = useRouter();
   const account = useCurrentAccount();
   const { profile, refetch } = useProfile();
+  const { ratings } = useRatings();
 
   return (
     <div className="h-full w-full  items-center justify-center">
@@ -56,6 +67,25 @@ export default function MatchesPage() {
                   />
                 </Card>
               </div>
+              <Card className="w-full max-w-xl mx-32 mt-4 p-4 space-y-2">
+                <h4 className="font-bold text-large">Leaderboard</h4>
+                <Table aria-label="rankings">
+                  <TableHeader>
+                    <TableColumn>Rank</TableColumn>
+                    <TableColumn>Address</TableColumn>
+                    <TableColumn>Points</TableColumn>
+                  </TableHeader>
+                  <TableBody>
+                    {ratings.map((r, idx) => (
+                      <TableRow key={r.address}>
+                        <TableCell>{idx + 1}</TableCell>
+                        <TableCell>{r.address}</TableCell>
+                        <TableCell>{r.points}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </Card>
             </>
           ) : (
             <ProfileForm onCreated={refetch} />

--- a/client/next-js/app/rating/page.tsx
+++ b/client/next-js/app/rating/page.tsx
@@ -31,9 +31,9 @@ export default function RatingPage() {
             </TableHeader>
             <TableBody>
               {ratings.map((r, idx) => (
-                <TableRow key={r.name}>
+                <TableRow key={r.address}>
                   <TableCell>{idx + 1}</TableCell>
-                  <TableCell>{r.name}</TableCell>
+                  <TableCell>{r.address}</TableCell>
                   <TableCell>{r.points}</TableCell>
                 </TableRow>
               ))}

--- a/client/next-js/hooks/useRatings.ts
+++ b/client/next-js/hooks/useRatings.ts
@@ -1,21 +1,51 @@
+import { useEffect, useState } from "react";
+import { useWS } from "./useWS";
+
 export interface RatingItem {
-  name: string;
+  address: string;
   points: number;
 }
 
 export const useRatings = () => {
-  const ratings: RatingItem[] = [
-    { name: "NFT #1", points: 1500 },
-    { name: "NFT #2", points: 1400 },
-    { name: "NFT #3", points: 1300 },
-    { name: "NFT #4", points: 1200 },
-    { name: "NFT #5", points: 1100 },
-    { name: "NFT #6", points: 1000 },
-    { name: "NFT #7", points: 900 },
-    { name: "NFT #8", points: 800 },
-    { name: "NFT #9", points: 700 },
-    { name: "NFT #10", points: 600 },
-  ];
+  const [ratings, setRatings] = useState<RatingItem[]>([]);
+
+  const { socket, sendToSocket } = useWS();
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      let message: any = {};
+      try {
+        message = JSON.parse(event.data);
+      } catch (e) {
+        return;
+      }
+
+      if (message.type === "RANKINGS" && Array.isArray(message.rankings)) {
+        setRatings(
+          message.rankings.map(([address, points]: [string, number]) => ({
+            address,
+            points,
+          })),
+        );
+      }
+    };
+
+    const handleOpen = () => {
+      sendToSocket({ type: "GET_RANKINGS" });
+    };
+
+    socket.addEventListener("message", handleMessage);
+    if (socket.readyState === WebSocket.OPEN) {
+      sendToSocket({ type: "GET_RANKINGS" });
+    } else {
+      socket.addEventListener("open", handleOpen);
+    }
+
+    return () => {
+      socket.removeEventListener("message", handleMessage);
+      socket.removeEventListener("open", handleOpen);
+    };
+  }, []);
 
   return { ratings };
 };


### PR DESCRIPTION
## Summary
- keep rankings only in memory and remove JSON file
- include rank delta in match summary data
- display rank delta column on summary page

## Testing
- `npm --prefix client/next-js run lint`


------
https://chatgpt.com/codex/tasks/task_e_685fa87f25a4832986418be0657a5fdb