### PR TITLE
Fix fireball tail sprites

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -1931,15 +1931,8 @@ export function Game({models, sounds, textures, matchId, character}) {
                 tailSprites = [];
                 tailPositions = [];
                 for (let i = 0; i < FIREBALL_TAIL_SEGMENTS; i++) {
-                    const mat = new THREE.SpriteMaterial({
-                        map: fireTexture,
-                        transparent: true,
-                        depthWrite: false,
-                        blending: THREE.AdditiveBlending,
-                    });
-                    const sprite = new THREE.Sprite(mat);
                     const scale = 0.15 * (1 - i / FIREBALL_TAIL_SEGMENTS);
-                    sprite.scale.set(scale, scale * 2, 1);
+                    const sprite = makeGlowSprite(0xff6600, scale);
                     sprite.visible = false;
                     scene.add(sprite);
                     tailSprites.push(sprite);
@@ -3664,15 +3657,8 @@ export function Game({models, sounds, textures, matchId, character}) {
                 tailSprites = [];
                 tailPositions = [];
                 for (let i = 0; i < FIREBALL_TAIL_SEGMENTS; i++) {
-                    const mat = new THREE.SpriteMaterial({
-                        map: fireTexture,
-                        transparent: true,
-                        depthWrite: false,
-                        blending: THREE.AdditiveBlending,
-                    });
-                    const sprite = new THREE.Sprite(mat);
                     const scale = 0.15 * (1 - i / FIREBALL_TAIL_SEGMENTS);
-                    sprite.scale.set(scale, scale * 2, 1);
+                    const sprite = makeGlowSprite(0xff6600, scale);
                     sprite.visible = false;
                     scene.add(sprite);
                     tailSprites.push(sprite);


### PR DESCRIPTION
## Summary
- refine fireball tail creation so it uses existing glow sprites tinted orange

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685fcf6cc9d083298e9fe7faf1d1b48e