### PR TITLE
Fix melee indicator orientation

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -307,6 +307,8 @@ export function Game({models, sounds, textures, matchId, character}) {
                 });
                 meleeRangeIndicator = new THREE.Mesh(geo, mat);
                 meleeRangeIndicator.rotation.x = -Math.PI / 2;
+                // Rotate indicator to face forward
+                meleeRangeIndicator.rotation.y = Math.PI;
                 meleeRangeIndicator.position.y = 0.05;
             }
             newModel.add(meleeRangeIndicator);
@@ -3408,6 +3410,8 @@ export function Game({models, sounds, textures, matchId, character}) {
                     const mat = new THREE.MeshBasicMaterial({ color: 0xff0000, transparent: true, opacity: 0.4, side: THREE.DoubleSide });
                     meleeRangeIndicator = new THREE.Mesh(geo, mat);
                     meleeRangeIndicator.rotation.x = -Math.PI / 2;
+                    // Rotate indicator to face forward
+                    meleeRangeIndicator.rotation.y = Math.PI;
                     meleeRangeIndicator.position.y = 0.05;
                     meleeRangeIndicator.scale.setScalar(1 / currentScale);
                     player.add(meleeRangeIndicator);


### PR DESCRIPTION
## Summary
- rotate melee attack indicator so it appears in front of the character

## Testing
- `npx -y eslint@8 -c .eslintrc.json components/game.jsx`

------
https://chatgpt.com/codex/tasks/task_e_685fcfa6c0c08329b620f85a5351ab14