### PR TITLE
Add per-class HP and armor system

### DIFF
--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -8,6 +8,7 @@ import {Buffs} from "../parts/Buffs";
 import {ComboPoints} from "../parts/ComboPoints";
 import {ExperienceBar} from "../parts/ExperienceBar";
 import {LevelUp} from "../parts/LevelUp";
+import {StatsModal} from "../parts/StatsModal";
 import {Progress} from "@heroui/react";
 
 import {useInterface} from "@/context/inteface";
@@ -22,8 +23,10 @@ export const Interface = () => {
     const {
         state: { character },
     } = useInterface() as { state: { character: { name?: string, classType: string } | null } };
-    const [target, setTarget] = useState<{id:number, hp:number, mana:number, address:string, classType?:string, buffs?:any[], debuffs?:any[]}|null>(null);
-    const [selfStats, setSelfStats] = useState<{hp:number, mana:number, points:number, level:number, skillPoints:number, learnedSkills:Record<string, boolean>}>({hp: MAX_HP, mana: MAX_MANA, points: 0, level: 1, skillPoints:1, learnedSkills:{}});
+    const [target, setTarget] = useState<{id:number, hp:number, armor:number, maxHp:number, maxArmor:number, mana:number, address:string, classType?:string, buffs?:any[], debuffs?:any[]}|null>(null);
+    const [selfStats, setSelfStats] = useState<{hp:number, mana:number, armor:number, maxHp:number, maxArmor:number, points:number, level:number, skillPoints:number, learnedSkills:Record<string, boolean>}>(
+        {hp: MAX_HP, mana: MAX_MANA, armor: 0, maxHp: MAX_HP, maxArmor: 0, points: 0, level: 1, skillPoints:1, learnedSkills:{}}
+    );
 
     useEffect(() => {
         const handler = (e: CustomEvent) => {
@@ -40,6 +43,9 @@ export const Interface = () => {
                 if (
                     prev.hp === e.detail.hp &&
                     prev.mana === e.detail.mana &&
+                    prev.armor === e.detail.armor &&
+                    prev.maxHp === e.detail.maxHp &&
+                    prev.maxArmor === e.detail.maxArmor &&
                     prev.points === e.detail.points &&
                     prev.level === e.detail.level &&
                     prev.skillPoints === e.detail.skillPoints
@@ -62,8 +68,8 @@ export const Interface = () => {
                     </div>
                 )}
                 <div className="w-40 space-y-1">
-                    <p className="text-medium font-semibold">HP: {Math.round((selfStats.hp / MAX_HP) * 100)}</p>
-                    <Progress id="hpBar" aria-label="HP" value={Math.round((selfStats.hp / MAX_HP) * 100)} color="secondary" disableAnimation />
+                    <p className="text-medium font-semibold">HP: {Math.round((selfStats.hp / selfStats.maxHp) * 100)}</p>
+                    <Progress id="hpBar" aria-label="HP" value={Math.round((selfStats.hp / selfStats.maxHp) * 100)} color="secondary" disableAnimation />
                     <p className="text-medium font-semibold">{(character.classType === 'rogue' || character.classType === 'warrior') ? 'Energy' : 'Mana'}: {Math.round(selfStats.mana)}</p>
                     <Progress id="manaBar" aria-label={(character.classType === 'rogue' || character.classType === 'warrior') ? 'Energy' : 'Mana'} value={Math.round((selfStats.mana / MAX_MANA) * 100)} color="primary" disableAnimation />
                     <ComboPoints />
@@ -79,8 +85,8 @@ export const Interface = () => {
                     )}
                     <div className="flex flex-col">
                         <div id="targetAddress" className="target-address">{target.address}</div>
-                        <p className="text-medium font-semibold">HP: {Math.round((target.hp / MAX_HP) * 100)}</p>
-                        <Progress id="targetHpBar" aria-label="Target HP" value={Math.round((target.hp / MAX_HP) * 100)} color="secondary" className="mb-1 w-40" disableAnimation />
+                        <p className="text-medium font-semibold">HP: {Math.round((target.hp / target.maxHp) * 100)}</p>
+                        <Progress id="targetHpBar" aria-label="Target HP" value={Math.round((target.hp / target.maxHp) * 100)} color="secondary" className="mb-1 w-40" disableAnimation />
                         <p className="text-medium font-semibold">{(target.classType === 'rogue' || target.classType === 'warrior') ? 'Energy' : 'Mana'}: {Math.round(target.mana)}</p>
                         <Progress id="targetManaBar" aria-label={(target.classType === 'rogue' || target.classType === 'warrior') ? 'Target Energy' : 'Target Mana'} value={Math.round((target.mana / MAX_MANA) * 100)} color="primary" className="w-40" disableAnimation />
                     </div>
@@ -116,6 +122,7 @@ export const Interface = () => {
 
 
             <Scoreboard />
+            <StatsModal />
             <GameMenu />
             <Buffs />
             <SkillBar mana={selfStats.mana} level={selfStats.level} skillPoints={selfStats.skillPoints} learnedSkills={selfStats.learnedSkills}/>

--- a/client/next-js/components/parts/StatsModal.css
+++ b/client/next-js/components/parts/StatsModal.css
@@ -1,0 +1,13 @@
+.stats-overlay {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    padding: 20px;
+    border-radius: 10px;
+    z-index: 1000;
+    min-width: 220px;
+    text-align: center;
+}

--- a/client/next-js/components/parts/StatsModal.jsx
+++ b/client/next-js/components/parts/StatsModal.jsx
@@ -1,0 +1,33 @@
+import { useInterface } from "../../context/inteface";
+import { useEffect, useState } from "react";
+import './StatsModal.css';
+
+export const StatsModal = () => {
+    const { state: { statsVisible, character } } = useInterface();
+    const [stats, setStats] = useState({hp:0, armor:0, maxHp:0, maxArmor:0});
+
+    useEffect(() => {
+        const handler = (e) => {
+            if (e.detail) {
+                setStats({
+                    hp: e.detail.hp,
+                    armor: e.detail.armor,
+                    maxHp: e.detail.maxHp,
+                    maxArmor: e.detail.maxArmor,
+                });
+            }
+        };
+        window.addEventListener('self-update', handler);
+        return () => window.removeEventListener('self-update', handler);
+    }, []);
+
+    if (!statsVisible) return null;
+
+    return (
+        <div className="stats-overlay">
+            <h2 className="stats-title">{character?.classType} stats</h2>
+            <p>HP: {stats.hp} / {stats.maxHp}</p>
+            <p>Armor: {stats.armor} / {stats.maxArmor}</p>
+        </div>
+    );
+};

--- a/client/next-js/consts/classStats.json
+++ b/client/next-js/consts/classStats.json
@@ -1,0 +1,7 @@
+{
+  "mage": { "hp": 100, "armor": 20 },
+  "warlock": { "hp": 110, "armor": 25 },
+  "paladin": { "hp": 150, "armor": 40 },
+  "rogue": { "hp": 120, "armor": 30 },
+  "warrior": { "hp": 160, "armor": 50 }
+}

--- a/client/next-js/consts/index.ts
+++ b/client/next-js/consts/index.ts
@@ -12,3 +12,4 @@ export const MAX_MANA = 130;
 export const XP_PER_LEVEL = 1000;
 export { default as SPELL_COST } from './spellCosts.json';
 export { default as CLASS_MODELS } from './classModels.json';
+export { default as CLASS_STATS } from './classStats.json';

--- a/client/next-js/context/inteface.jsx
+++ b/client/next-js/context/inteface.jsx
@@ -7,6 +7,7 @@ export const initInterfaceState = {
     character: null,
     scoreboardData: [],
     scoreboardVisible: false,
+    statsVisible: false,
     menuVisible: false,
     buffs: [],
     debuffs: [],
@@ -29,6 +30,9 @@ export const interfaceReducer = (state, action) => {
         }
         case 'SET_SCOREBOARD_VISIBLE': {
             return {...state, scoreboardVisible: action.payload};
+        }
+        case 'SET_STATS_VISIBLE': {
+            return {...state, statsVisible: action.payload};
         }
         case 'SET_MENU_VISIBLE': {
             return {...state, menuVisible: action.payload};


### PR DESCRIPTION
## Summary
- add config `classStats.json` with HP and armor per class
- expose stats in consts and load on server
- track `maxHp` and `armor` for players on server
- broadcast stats including armor and max values
- handle armor when dealing damage
- expose stats to client and show in new `StatsModal`
- toggle modal with `C` key using new `statsVisible` state

## Testing
- `npm test --prefix server` *(fails: Error: no test specified)*
- `npm run lint --prefix client/next-js` *(fails to find eslint plugin)*

------
https://chatgpt.com/codex/tasks/task_e_685fe25ad3ec8329a1b9937e1828cc13