### PR TITLE
Adjust HP and armor mechanics

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -312,7 +312,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                 meleeRangeIndicator = new THREE.Mesh(geo, mat);
                 meleeRangeIndicator.rotation.x = -Math.PI / 2;
                 // Rotate indicator to face forward
-                meleeRangeIndicator.rotation.y = Math.PI;
+                meleeRangeIndicator.rotation.y = 0;
                 meleeRangeIndicator.position.y = 0.05;
             }
             newModel.add(meleeRangeIndicator);
@@ -831,7 +831,7 @@ export function Game({models, sounds, textures, matchId, character}) {
         const LIGHTSTRIKE_DAMAGE = 34; // increased for warrior/paladin/rogue E
         // Slightly increased to improve melee reliability
         // Increase melee range by 25%
-        const MELEE_RANGE_ATTACK = 2.125; // melee range
+        const MELEE_RANGE_ATTACK = 1.9125; // melee range reduced by 10%
         // Melee arc in radians (120 degrees)
         const MELEE_ANGLE = (120 * Math.PI) / 180;
         const LIGHTWAVE_DAMAGE = 40;
@@ -3419,7 +3419,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                     meleeRangeIndicator = new THREE.Mesh(geo, mat);
                     meleeRangeIndicator.rotation.x = -Math.PI / 2;
                     // Rotate indicator to face forward
-                    meleeRangeIndicator.rotation.y = Math.PI;
+                    meleeRangeIndicator.rotation.y = 0;
                     meleeRangeIndicator.position.y = 0.05;
                     meleeRangeIndicator.scale.setScalar(1 / currentScale);
                     player.add(meleeRangeIndicator);

--- a/client/next-js/consts/classStats.json
+++ b/client/next-js/consts/classStats.json
@@ -1,7 +1,7 @@
 {
-  "mage": { "hp": 100, "armor": 20 },
-  "warlock": { "hp": 110, "armor": 25 },
+  "mage": { "hp": 150, "armor": 20 },
+  "warlock": { "hp": 150, "armor": 25 },
   "paladin": { "hp": 150, "armor": 40 },
-  "rogue": { "hp": 120, "armor": 30 },
-  "warrior": { "hp": 160, "armor": 50 }
+  "rogue": { "hp": 150, "armor": 30 },
+  "warrior": { "hp": 150, "armor": 50 }
 }

--- a/client/next-js/consts/index.ts
+++ b/client/next-js/consts/index.ts
@@ -6,7 +6,7 @@ export const NETWORK = process.env.NEXT_PUBLIC_NETWORK as
 export const TREASURY_CAP_ID = process.env.NEXT_PUBLIC_TREASURY_CAP_ID;
 
 // Base health for players. Used for health bar calculations on both client and server
-export const MAX_HP = 120;
+export const MAX_HP = 150;
 export const MAX_MANA = 130;
 // Amount of experience required for each level
 export const XP_PER_LEVEL = 1000;

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -5,7 +5,7 @@ const http = require('http');
 // const { createProfile } = require('./sui.cjs');
 
 const UPDATE_MATCH_INTERVAL = 33;
-const MAX_HP = 120;
+const MAX_HP = 150;
 const MAX_MANA = 130;
 const MAX_KILLS = 15;
 const XP_PER_LEVEL = 1000;
@@ -20,7 +20,7 @@ const COMBO_ICON = '/icons/classes/rogue/combo_point.jpg';
 const ROGUE_SPRINT_ICON = '/icons/classes/rogue/sprint.jpg';
 const CLASS_STATS = require('../client/next-js/consts/classStats.json');
 const ADRENALINE_RUSH_ICON = '/icons/classes/rogue/adrenalinerush.jpg';
-const MELEE_RANGE = 2.125;
+const MELEE_RANGE = 1.9125; // reduced by 10%
 const LIGHTSTRIKE_DAMAGE = 34;
 
 function withinMeleeRange(a, b) {
@@ -394,9 +394,11 @@ function applyDamage(match, victimId, dealerId, damage, spellType) {
         });
     }
 
-    const absorbed = Math.min(victim.armor, totalDamage);
-    victim.armor -= absorbed;
-    totalDamage -= absorbed;
+    // Armor reduces damage but is not consumed
+    if (victim.armor > 0) {
+        const reduction = Math.min(1, victim.armor / 100);
+        totalDamage = totalDamage * (1 - reduction);
+    }
     victim.hp = Math.max(0, victim.hp - totalDamage);
     if (victim.hp <= 0) {
         victim.deaths++;


### PR DESCRIPTION
## Summary
- bump base HP to 150 in server and client constants
- give all classes 150 HP while keeping class armor differences
- make armor reduce incoming damage without being consumed
- shrink melee range by 10% and point melee indicator forward

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_6861078f3f4c8329a4c2d9e172b8b302