### PR TITLE
Add 1s cast time for major spells

### DIFF
--- a/client/next-js/skills/mage/fireball.js
+++ b/client/next-js/skills/mage/fireball.js
@@ -7,11 +7,11 @@ export default function castFireball({ playerId, castSpellImpl, igniteHands, cas
   castSpellImpl(
     playerId,
     SPELL_COST['fireball'],
-    500,
+    1000,
     (model) => castSphere(model, fireballMesh.clone(), meta.id, damage),
     sounds.fireballCast,
     sounds.fireball,
     meta.id,
-    true
+    false
   );
 }

--- a/client/next-js/skills/mage/pyroblast.js
+++ b/client/next-js/skills/mage/pyroblast.js
@@ -7,11 +7,11 @@ export default function castPyroblast({ playerId, castSpellImpl, igniteHands, ca
   castSpellImpl(
     playerId,
     SPELL_COST['pyroblast'],
-    0,
+    1000,
     (model) => castSphere(model, pyroblastMesh.clone(), meta.id, damage),
     sounds.fireballCast,
     sounds.fireball,
     meta.id,
-    true
+    false
   );
 }

--- a/client/next-js/skills/warlock/chaosBolt.js
+++ b/client/next-js/skills/warlock/chaosBolt.js
@@ -7,11 +7,11 @@ export default function castChaosBolt({ playerId, castSpellImpl, igniteHands, ca
   castSpellImpl(
     playerId,
     SPELL_COST['chaosbolt'],
-    0,
+    1000,
     (model) => castSphere(model, chaosBoltMesh.clone(), meta.id, damage),
     sounds.fireballCast,
     sounds.fireball,
     meta.id,
-    true
+    false
   );
 }

--- a/client/next-js/skills/warlock/darkball.js
+++ b/client/next-js/skills/warlock/darkball.js
@@ -7,11 +7,11 @@ export default function castDarkball({ playerId, castSpellImpl, igniteHands, cas
   castSpellImpl(
     playerId,
     SPELL_COST['darkball'],
-    500,
+    1000,
     (model) => castSphere(model, darkballMesh.clone(), meta.id, damage),
     sounds.fireballCast,
     sounds.fireball,
     meta.id,
-    true
+    false
   );
 }


### PR DESCRIPTION
## Summary
- update fireball to use a 1 second cast time
- update pyroblast to use a 1 second cast time
- update darkball to use a 1 second cast time
- update chaos bolt to use a 1 second cast time

## Testing
- `npm run lint` *(fails: eslint-plugin-react not found)*

------
https://chatgpt.com/codex/tasks/task_e_68610ba48a7083299d6dc23b5301fb77