### PR TITLE
Require target for lifedrain at cast completion

### DIFF
--- a/client/next-js/skills/warlock/lifeDrain.js
+++ b/client/next-js/skills/warlock/lifeDrain.js
@@ -2,7 +2,15 @@ import { SPELL_COST } from '../../consts';
 
 export const meta = { id: 'lifedrain', key: '2', icon: '/icons/classes/warlock/lifedrain.jpg' };
 
-export default function castLifeDrain({ playerId, castSpellImpl, mana, getTargetPlayer, dispatch, sendToSocket, sounds }) {
+export default function castLifeDrain({
+  playerId,
+  castSpellImpl,
+  mana,
+  getTargetPlayer,
+  dispatch,
+  sendToSocket,
+  sounds,
+}) {
   if (mana < SPELL_COST['lifedrain']) {
     if (sounds?.noMana) {
       sounds.noMana.currentTime = 0;
@@ -11,17 +19,20 @@ export default function castLifeDrain({ playerId, castSpellImpl, mana, getTarget
     }
     return;
   }
-  const targetId = getTargetPlayer();
-  if (!targetId) {
-    dispatch({ type: 'SEND_CHAT_MESSAGE', payload: `No target for lifedrain!` });
-    sounds?.noTarget?.play?.();
-    return;
-  }
+
   castSpellImpl(
     playerId,
     SPELL_COST['lifedrain'],
     1000,
-    () => sendToSocket({ type: 'CAST_SPELL', payload: { type: 'lifedrain', targetId } }),
+    () => {
+      const targetId = getTargetPlayer();
+      if (!targetId) {
+        dispatch({ type: 'SEND_CHAT_MESSAGE', payload: `No target for lifedrain!` });
+        sounds?.noTarget?.play?.();
+        return;
+      }
+      sendToSocket({ type: 'CAST_SPELL', payload: { type: 'lifedrain', targetId } });
+    },
     sounds.spellCast,
     sounds.spellCast,
     meta.id,


### PR DESCRIPTION
## Summary
- check warlock `lifedrain` target at the end of the cast

## Testing
- `npm run lint` *(fails: ESLint plugin initially missing, installed then run with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68610bd1a0408329bd98d5cdff5b8c80