### PR TITLE
Add basic health regeneration

### DIFF
--- a/server/server.cjs
+++ b/server/server.cjs
@@ -11,6 +11,7 @@ const MAX_KILLS = 15;
 const XP_PER_LEVEL = 1000;
 const MANA_REGEN_INTERVAL = 1000;
 const MANA_REGEN_AMOUNT = 1.3; // 30% faster mana regeneration
+const HP_REGEN_AMOUNT = 0.8; // Basic health regeneration per tick
 const SPELL_COST = require('../client/next-js/consts/spellCosts.json');
 const ICEBALL_ICON = '/icons/spell_frostbolt.jpg';
 const FROSTNOVA_ICON = '/icons/frostnova.jpg';
@@ -477,6 +478,9 @@ ws.on('connection', (socket) => {
             match.players.forEach((player, pid) => {
                 if (player.mana < MAX_MANA) {
                     player.mana = Math.min(MAX_MANA, player.mana + MANA_REGEN_AMOUNT);
+                }
+                if (player.hp < player.maxHp) {
+                    player.hp = Math.min(player.maxHp, player.hp + HP_REGEN_AMOUNT);
                 }
                 if (player.buffs.length) {
                     player.buffs = player.buffs.filter(b => {


### PR DESCRIPTION
## Summary
- implement health regeneration in the server loop
- define `HP_REGEN_AMOUNT` constant

## Testing
- `npm test --prefix server` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68611d15024c83299d0f392a88c8aff7