### PR TITLE
Implement hold-to-cast mechanic

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -1113,6 +1113,15 @@ export function Game({models, sounds, textures, matchId, character}) {
             KeyQ: handleKeyQ,
         };
 
+        const skillKeyCodes = new Set([
+            'KeyE',
+            'KeyR',
+            'KeyF',
+            'Digit3',
+            'Digit2',
+            'KeyQ',
+        ]);
+
         document.addEventListener("keydown", (event) => {
             if (event.code === "Escape") {
                 handleEscape();
@@ -1168,6 +1177,10 @@ export function Game({models, sounds, textures, matchId, character}) {
 
             const handler = keyUpHandlers[event.code];
             if (handler) handler();
+
+            if (isCasting && skillKeyCodes.has(event.code)) {
+                dispatchEvent('release-cast');
+            }
 
             // // Check if no movement keys are active
             if (

--- a/client/next-js/components/parts/CastBar.jsx
+++ b/client/next-js/components/parts/CastBar.jsx
@@ -17,7 +17,6 @@ export const CastBar = () => {
             onEndRef.current = onEnd;
             setProgress(0);
             setIsCasting(true);
-
             startRef.current = Date.now();
 
             if (intervalRef.current) clearInterval(intervalRef.current);
@@ -26,22 +25,35 @@ export const CastBar = () => {
                 const elapsed = Date.now() - startRef.current;
                 const percent = Math.min((elapsed / durationRef.current) * 100, 100);
                 setProgress(percent);
-
                 if (percent >= 100) {
                     clearInterval(intervalRef.current);
                     intervalRef.current = null;
-                    setIsCasting(false);
-                    onEndRef.current?.();
                 }
-            }, 30); // обновление каждые 30мс
+            }, 30);
+        };
+
+        const handleReleaseCast = () => {
+            if (!isCasting) return;
+            const elapsed = Date.now() - startRef.current;
+            const remaining = Math.max(0, durationRef.current - elapsed);
+            if (intervalRef.current) {
+                clearInterval(intervalRef.current);
+                intervalRef.current = null;
+            }
+            setTimeout(() => {
+                onEndRef.current?.();
+            }, remaining);
+            setIsCasting(false);
         };
 
         window.addEventListener("start-cast", handleStartCast);
+        window.addEventListener("release-cast", handleReleaseCast);
         return () => {
             window.removeEventListener("start-cast", handleStartCast);
+            window.removeEventListener("release-cast", handleReleaseCast);
             if (intervalRef.current) clearInterval(intervalRef.current);
         };
-    }, []);
+    }, [isCasting]);
 
     if (!isCasting) return null;
 

--- a/client/next-js/skills/warlock/fear.js
+++ b/client/next-js/skills/warlock/fear.js
@@ -13,17 +13,19 @@ export default function castFear({ playerId, castSpellImpl, mana, getTargetPlaye
     }
     return;
   }
-  const targetId = getTargetPlayer();
-  if (!targetId) {
-    dispatch({ type: 'SEND_CHAT_MESSAGE', payload: `No target for fear!` });
-    sounds?.noTarget?.play?.();
-    return;
-  }
   castSpellImpl(
     playerId,
     SPELL_COST['fear'],
     FEAR_CAST_TIME,
-    () => sendToSocket({ type: 'CAST_SPELL', payload: { type: 'fear', targetId } }),
+    () => {
+      const targetId = getTargetPlayer();
+      if (!targetId) {
+        dispatch({ type: 'SEND_CHAT_MESSAGE', payload: `No target for fear!` });
+        sounds?.noTarget?.play?.();
+        return;
+      }
+      sendToSocket({ type: 'CAST_SPELL', payload: { type: 'fear', targetId } });
+    },
     sounds.spellCast,
     sounds.spellCast,
     meta.id,

--- a/client/next-js/skills/warlock/immolate.js
+++ b/client/next-js/skills/warlock/immolate.js
@@ -22,19 +22,18 @@ export default function castImmolate({
     return;
   }
 
-  const targetId = getTargetPlayer();
-  if (!targetId) {
-    dispatch({ type: 'SEND_CHAT_MESSAGE', payload: `No target for immolate!` });
-    sounds?.noTarget?.play?.();
-    return;
-  }
-
   igniteHands(playerId, 1500);
   castSpellImpl(
     playerId,
     SPELL_COST['immolate'],
     1500,
     () => {
+      const targetId = getTargetPlayer();
+      if (!targetId) {
+        dispatch({ type: 'SEND_CHAT_MESSAGE', payload: `No target for immolate!` });
+        sounds?.noTarget?.play?.();
+        return;
+      }
       sendToSocket({ type: 'CAST_SPELL', payload: { type: 'immolate', targetId } });
     },
     sounds.fireballCast,


### PR DESCRIPTION
## Summary
- allow releasing cast via `release-cast` event
- play cast after releasing key
- get target on cast for immolate and fear spells
- dispatch release events from game logic

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_68611ed5d4d48329985e81028cb794a4