### PR TITLE
Slow down Rune of Power animation

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -900,8 +900,8 @@ export function Game({models, sounds, textures, matchId, character}) {
         const DAMAGE_REDUCTION = 0.5; // Reduces damage by 50%
         const PRIORITY_ACTIONS = ['attack', 'attack_360'];
         // Rotation speed for the damage rune effect attached to players
-        const DAMAGE_EFFECT_ROT_SPEED = 0.4;
-        const DAMAGE_EFFECT_MAP_SPEED = 0.1;
+        const DAMAGE_EFFECT_ROT_SPEED = 0.2;
+        const DAMAGE_EFFECT_MAP_SPEED = 0.05;
         // Activate shield
         let isShieldActive = false;
         let isChatActive = false;
@@ -3302,7 +3302,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                     });
 
                     runes.forEach(r => {
-                        const speed = r.userData.type === 'damage' ? 0.05 : 0.1;
+                        const speed = r.userData.type === 'damage' ? 0.025 : 0.1;
                         r.rotation.y += delta * speed;
                     });
 


### PR DESCRIPTION
## Summary
- slow the Rune of Power rotation
- reduce the swirl animation speed for the damage rune effect

## Testing
- `npm run lint` *(fails: ESLint couldn't find plugin `eslint-plugin-react`)*

------
https://chatgpt.com/codex/tasks/task_e_686122649f8883298adc2745c597098e