### PR TITLE
Fix CastBar not completing

### DIFF
--- a/client/next-js/components/parts/CastBar.jsx
+++ b/client/next-js/components/parts/CastBar.jsx
@@ -9,6 +9,11 @@ export const CastBar = () => {
     const startRef = useRef(0);
     const durationRef = useRef(1500);
     const onEndRef = useRef(() => {});
+    const isCastingRef = useRef(false);
+
+    useEffect(() => {
+        isCastingRef.current = isCasting;
+    }, [isCasting]);
 
     useEffect(() => {
         const handleStartCast = (e) => {
@@ -33,7 +38,7 @@ export const CastBar = () => {
         };
 
         const handleReleaseCast = () => {
-            if (!isCasting) return;
+            if (!isCastingRef.current) return;
             const elapsed = Date.now() - startRef.current;
             const remaining = Math.max(0, durationRef.current - elapsed);
             if (intervalRef.current) {
@@ -53,7 +58,7 @@ export const CastBar = () => {
             window.removeEventListener("release-cast", handleReleaseCast);
             if (intervalRef.current) clearInterval(intervalRef.current);
         };
-    }, [isCasting]);
+    }, []);
 
     if (!isCasting) return null;
 


### PR DESCRIPTION
## Summary
- fix cast bar progression stopping too early

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_686122576fd08329b842a1b9d4c8a152