### PR TITLE
Fix rogue mechanics and armor calculation

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -264,6 +264,8 @@ export function Game({models, sounds, textures, matchId, character}) {
                 transparent: true,
                 opacity: MELEE_INDICATOR_OPACITY,
                 side: THREE.DoubleSide,
+                depthWrite: false,
+                blending: THREE.AdditiveBlending,
             });
             const wedge = new THREE.Mesh(geo, mat);
             group.add(wedge);
@@ -1898,6 +1900,12 @@ export function Game({models, sounds, textures, matchId, character}) {
         function performBloodStrike() {
             const playerData = players.get(myPlayerId);
             if (!playerData) return;
+            const targetId = getTargetPlayer();
+            if (!targetId) {
+                dispatch({ type: 'SEND_CHAT_MESSAGE', payload: `No target for blood strike!` });
+                sounds?.noTarget?.play?.();
+                return;
+            }
             const { mixer, actions } = playerData;
 
 
@@ -1919,7 +1927,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                 sounds.sinisterStrike.play();
             }
 
-            sendToSocket({ type: 'CAST_SPELL', payload: { type: 'blood-strike' } });
+            sendToSocket({ type: 'CAST_SPELL', payload: { type: 'blood-strike', targetId } });
             activateGlobalCooldown();
             startSkillCooldown('blood-strike');
         }

--- a/client/next-js/skills/rogue/bloodStrike.js
+++ b/client/next-js/skills/rogue/bloodStrike.js
@@ -7,7 +7,17 @@ export const meta = {
   autoFocus: false,
 };
 
-export default function castBloodStrike({ globalSkillCooldown, isCasting, mana, sendToSocket, activateGlobalCooldown, startSkillCooldown, sounds }) {
+export default function castBloodStrike({
+  globalSkillCooldown,
+  isCasting,
+  mana,
+  getTargetPlayer,
+  dispatch,
+  sendToSocket,
+  activateGlobalCooldown,
+  startSkillCooldown,
+  sounds,
+}) {
   if (globalSkillCooldown || isCasting) return;
   if (mana < SPELL_COST['blood-strike']) {
     if (sounds?.noMana) {
@@ -17,7 +27,14 @@ export default function castBloodStrike({ globalSkillCooldown, isCasting, mana, 
     }
     return;
   }
-  sendToSocket({ type: 'CAST_SPELL', payload: { type: 'blood-strike' } });
+  const targetId = getTargetPlayer?.();
+  if (!targetId) {
+    dispatch?.({ type: 'SEND_CHAT_MESSAGE', payload: `No target for blood strike!` });
+    sounds?.noTarget?.play?.();
+    return;
+  }
+
+  sendToSocket({ type: 'CAST_SPELL', payload: { type: 'blood-strike', targetId } });
   activateGlobalCooldown();
   startSkillCooldown('blood-strike');
 }

--- a/client/next-js/skills/rogue/shadowLeap.js
+++ b/client/next-js/skills/rogue/shadowLeap.js
@@ -61,13 +61,7 @@ export default function castShadowLeap({
   const backOffset = new THREE.Vector3(Math.sin(rotY), 0, Math.cos(rotY)).multiplyScalar(-BEHIND_DISTANCE);
   const behind = targetPos.clone().add(backOffset);
 
-  const intersect = worldOctree?.capsuleIntersect(
-    new Capsule(behind, behind.clone().add(new THREE.Vector3(0, 0.75, 0)), 0.35),
-  );
-
-  if (!intersect) {
-    teleportTo({ x: behind.x, y: behind.y, z: behind.z, yaw: rotY });
-  }
+  teleportTo({ x: behind.x, y: behind.y, z: behind.z, yaw: rotY });
 
   sendToSocket({ type: 'CAST_SPELL', payload: { type: 'shadow-leap', targetId } });
   activateGlobalCooldown();

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -396,9 +396,8 @@ function applyDamage(match, victimId, dealerId, damage, spellType) {
         });
     }
 
-    const absorbed = Math.min(victim.armor, totalDamage);
-    victim.armor -= absorbed;
-    totalDamage -= absorbed;
+    const reduction = victim.armor / 200; // 100 armor = 50% damage reduction
+    totalDamage = totalDamage * Math.max(0, 1 - reduction);
     victim.hp = Math.max(0, victim.hp - totalDamage);
     if (victim.hp <= 0) {
         victim.deaths++;


### PR DESCRIPTION
## Summary
- fix blood strike ability to require a target
- adjust rogue blood strike cast in game logic
- ensure melee indicator uses additive blending for opacity
- simplify shadow leap teleport logic
- adjust damage formula so armor reduces damage without depleting armor

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test` in client (fails: missing script)
- `npm run lint` in client (fails due to missing dependencies)

------
https://chatgpt.com/codex/tasks/task_e_686276d21e7c8329bc6669cd3ef5fe68