### PR TITLE
Limit melee indicator to melee classes

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -313,11 +313,18 @@ export function Game({models, sounds, textures, matchId, character}) {
             scene.remove(oldModel);
             scene.add(newModel);
             playerData.model = newModel;
-            if (!meleeRangeIndicator) {
-                meleeRangeIndicator = createMeleeIndicator();
+            const cls = playerData.classType;
+            const allowed = ['paladin', 'warrior', 'rogue'];
+            if (allowed.includes(cls)) {
+                if (!meleeRangeIndicator) {
+                    meleeRangeIndicator = createMeleeIndicator();
+                }
+                newModel.add(meleeRangeIndicator);
+                meleeRangeIndicator.scale.setScalar(1 / currentScale);
+            } else if (meleeRangeIndicator) {
+                meleeRangeIndicator.parent?.remove(meleeRangeIndicator);
+                meleeRangeIndicator = null;
             }
-            newModel.add(meleeRangeIndicator);
-            meleeRangeIndicator.scale.setScalar(1 / currentScale);
         };
 
         window.addEventListener('DEV_SCALE_CHANGE', handleScaleChange);
@@ -3442,7 +3449,10 @@ export function Game({models, sounds, textures, matchId, character}) {
 
 
                 scene.add(player);
-                if (id === myPlayerId) {
+                if (
+                    id === myPlayerId &&
+                    ['paladin', 'warrior', 'rogue'].includes(classType)
+                ) {
                     meleeRangeIndicator = createMeleeIndicator();
                     meleeRangeIndicator.scale.setScalar(1 / currentScale);
                     player.add(meleeRangeIndicator);

--- a/client/next-js/skills/warlock/lifeTap.js
+++ b/client/next-js/skills/warlock/lifeTap.js
@@ -1,6 +1,6 @@
 import { SPELL_COST } from '../../consts';
 
-export const meta = { id: 'lifetap', key: 'Q', icon: '/icons/classes/warlock/spell_immolation.jpg' };
+export const meta = { id: 'lifetap', key: 'Q', icon: '/icons/classes/warlock/spell_shadow_burningspirit.jpg' };
 
 export default function castLifeTap({
   playerId,


### PR DESCRIPTION
## Summary
- show the melee attack indicator only on paladin, warrior and rogue
- update Life Tap icon

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_68627714fba48329b59950d990bec69c