### PR TITLE
Add skill info to cast bar

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -1390,7 +1390,7 @@ export function Game({models, sounds, textures, matchId, character}) {
             movementSpeedModifier = 0.3;
             sounds.spellCast.volume = 0.3;
             sounds.spellCast.play();
-            dispatchEvent('start-cast', {duration: 2000, onEnd: onCastEnd})
+            dispatchEvent('start-cast', {duration: 2000, onEnd: onCastEnd, name: 'heal', icon: ''})
         }
 
         function getAimDirection() {
@@ -2159,7 +2159,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                     clampWhenFinished: true,
                 });
             }, duration * 0.5);
-            dispatchEvent('start-cast', { duration, onEnd: onCastEnd });
+            dispatchEvent('start-cast', { duration, onEnd: onCastEnd, icon: SPELL_META[spellType]?.icon, name: spellType });
         }
 
         function playerCollisions() {

--- a/client/next-js/components/parts/CastBar.jsx
+++ b/client/next-js/components/parts/CastBar.jsx
@@ -4,6 +4,8 @@ import { Progress } from "@heroui/react";
 export const CastBar = () => {
     const [isCasting, setIsCasting] = useState(false);
     const [progress, setProgress] = useState(0);
+    const [icon, setIcon] = useState('');
+    const [name, setName] = useState('');
 
     const intervalRef = useRef(null);
     const startRef = useRef(0);
@@ -17,9 +19,11 @@ export const CastBar = () => {
 
     useEffect(() => {
         const handleStartCast = (e) => {
-            const { duration = 1500, onEnd = () => {} } = e.detail || {};
+            const { duration = 1500, onEnd = () => {}, icon = '', name = '' } = e.detail || {};
             durationRef.current = duration;
             onEndRef.current = onEnd;
+            setIcon(icon);
+            setName(name);
             setProgress(0);
             setIsCasting(true);
             startRef.current = Date.now();
@@ -63,8 +67,17 @@ export const CastBar = () => {
     if (!isCasting) return null;
 
     return (
-        <div className="fixed bottom-40 left-1/2 transform -translate-x-1/2 w-64 z-50">
-            <Progress disableAnimation aria-label="Casting..." value={progress} color="warning" />
+        <div className="fixed bottom-40 left-1/2 transform -translate-x-1/2 w-64 z-50 flex flex-col items-center">
+            <div className="flex items-center gap-2 mb-1 text-white">
+                {icon && <img src={icon} alt={name} className="w-6 h-6" />}
+                <span className="capitalize">{name}</span>
+            </div>
+            <div className="relative w-full">
+                <Progress disableAnimation aria-label="Casting..." value={progress} color="warning" />
+                <span className="absolute inset-0 flex items-center justify-center text-white text-sm font-semibold">
+                    {Math.round(progress)}%
+                </span>
+            </div>
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- display icon, name, and percent on the CastBar component
- include skill metadata when dispatching `start-cast` events

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_6862a34a37e483299facb9bcce12f50e