### PR TITLE
Add damage and assist counters

### DIFF
--- a/client/next-js/app/matches/[id]/summary/page.tsx
+++ b/client/next-js/app/matches/[id]/summary/page.tsx
@@ -19,6 +19,8 @@ interface PlayerSummary {
   id: number;
   kills: number;
   deaths: number;
+  assists: number;
+  damage: number;
   reward: string;
   coins: number;
   item?: { class: string; skin: string } | null;
@@ -63,6 +65,8 @@ export default function MatchSummaryPage() {
               <TableColumn>Player</TableColumn>
               <TableColumn>Kills</TableColumn>
               <TableColumn>Deaths</TableColumn>
+              <TableColumn>Assists</TableColumn>
+              <TableColumn>Damage</TableColumn>
               <TableColumn>Reward</TableColumn>
               <TableColumn>Coins</TableColumn>
               <TableColumn>Item</TableColumn>
@@ -74,6 +78,8 @@ export default function MatchSummaryPage() {
                   <TableCell>{`Player ${p.id}`}</TableCell>
                   <TableCell>{p.kills}</TableCell>
                   <TableCell>{p.deaths}</TableCell>
+                  <TableCell>{p.assists}</TableCell>
+                  <TableCell>{p.damage}</TableCell>
                   <TableCell>{p.reward}</TableCell>
                   <TableCell>{p.coins}</TableCell>
                   <TableCell>

--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -4214,6 +4214,8 @@ export function Game({models, sounds, textures, matchId, character}) {
                         id: Number(id),
                         kills: p.kills,
                         deaths: p.deaths,
+                        assists: p.assists,
+                        damage: Math.floor(p.damage || 0),
                         points: p.points,
                         level: p.level,
                     }));

--- a/client/next-js/components/parts/Scoreboard.css
+++ b/client/next-js/components/parts/Scoreboard.css
@@ -11,7 +11,7 @@
 }
 
 .scoreboard-table {
-    width: 300px;
+    width: 460px;
     border-collapse: collapse;
 }
 

--- a/client/next-js/components/parts/Scoreboard.jsx
+++ b/client/next-js/components/parts/Scoreboard.jsx
@@ -14,6 +14,8 @@ export const Scoreboard = () => {
                     <th>Player</th>
                     <th>Kills</th>
                     <th>Deaths</th>
+                    <th>Assists</th>
+                    <th>Damage</th>
                     <th>Points</th>
                 </tr>
                 </thead>
@@ -23,6 +25,8 @@ export const Scoreboard = () => {
                         <td>{`Player ${p.id}`}</td>
                         <td>{p.kills}</td>
                         <td>{p.deaths}</td>
+                        <td>{p.assists}</td>
+                        <td>{p.damage}</td>
                         <td>{p.points}</td>
                     </tr>
                 ))}


### PR DESCRIPTION
## Summary
- track player damage and assists on the server
- send these stats to the client for display
- extend scoreboard UI with damage and assist columns
- show damage and assists in match summary tables

## Testing
- `npm test` in `server` *(fails: no test specified)*
- `npm test` in `client/next-js` *(fails: missing test script)*
- `npm run lint` in `client/next-js` *(fails: ESLint couldn't find eslint-plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_6862a3741e588329a4a8de08d6fc24bb