### PR TITLE
Add Target Help modal

### DIFF
--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -10,6 +10,7 @@ import {ExperienceBar} from "../parts/ExperienceBar";
 import {LevelUp} from "../parts/LevelUp";
 import {StatsModal} from "../parts/StatsModal";
 import {HowToPlayModal} from "../parts/HowToPlayModal";
+import {TargetHelpModal} from "../parts/TargetHelpModal";
 import {Progress} from "@heroui/react";
 
 import {useInterface} from "@/context/inteface";
@@ -144,6 +145,7 @@ export const Interface = () => {
             <Scoreboard />
             <StatsModal />
             <HowToPlayModal />
+            <TargetHelpModal />
             <GameMenu />
             <Buffs />
             <SkillBar mana={selfStats.mana} level={selfStats.level} skillPoints={selfStats.skillPoints} learnedSkills={selfStats.learnedSkills}/>

--- a/client/next-js/components/parts/TargetHelpModal.css
+++ b/client/next-js/components/parts/TargetHelpModal.css
@@ -1,0 +1,43 @@
+.target-help-overlay {
+    position: fixed;
+    bottom: 30px;
+    right: 30px;
+    width: 250px;
+    height: 300px;
+    padding: 30px;
+    background-color: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    border-radius: 10px;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+}
+
+.target-help-title {
+    text-align: center;
+    margin-bottom: 10px;
+    font-size: 1.2rem;
+}
+
+.target-help-body {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.target-help-actions {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 10px;
+}
+
+.target-help-button {
+    padding: 5px 10px;
+    border: none;
+    border-radius: 5px;
+    background-color: #ffffff;
+    color: #000;
+    cursor: pointer;
+    font-size: 14px;
+}

--- a/client/next-js/components/parts/TargetHelpModal.jsx
+++ b/client/next-js/components/parts/TargetHelpModal.jsx
@@ -1,0 +1,53 @@
+import { useEffect, useState, useCallback } from "react";
+import "./TargetHelpModal.css";
+
+const STORAGE_KEY = 'hideTargetHelp';
+
+export const TargetHelpModal = () => {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const hide = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : 'true';
+    if (!hide) {
+      setOpen(true);
+    }
+  }, []);
+
+  const close = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  const dontShowAgain = () => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(STORAGE_KEY, 'true');
+    }
+    setOpen(false);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        close();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, close]);
+
+  if (!open) return null;
+
+  return (
+    <div className="target-help-overlay">
+      <h2 className="target-help-title">Target Help</h2>
+      <div className="target-help-body">
+        <img src="/icons/target-green.svg" alt="Target Help" className="target-help-image" />
+      </div>
+      <div className="target-help-actions">
+        <button className="target-help-button" onClick={dontShowAgain}>Don't show again</button>
+        <button className="target-help-button" onClick={close}>Close (Enter or Space)</button>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add a `TargetHelpModal` component with local storage logic similar to `HowToPlayModal`
- style the modal so it appears 250x300px in the bottom right corner
- include new modal in the game `Interface`

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_6862a3b66930832994f0ed96ca2db703