### PR TITLE
Add rogue skill metadata and tidy utilities

### DIFF
--- a/client/next-js/components/navbar.tsx
+++ b/client/next-js/components/navbar.tsx
@@ -33,7 +33,7 @@ import {
     SearchIcon,
     CoinIcon,
 } from "@/components/icons";
-import {convertMistToSui} from "@/utiltiies";
+import {convertMistToSui} from "@/utilities";
 import {ConnectionButton} from "@/components/connection-button";
 
 let clickedOnBalance = 0;

--- a/client/next-js/skills/rogue/kidneyStrike.js
+++ b/client/next-js/skills/rogue/kidneyStrike.js
@@ -4,6 +4,7 @@ export const meta = {
   id: 'kidney-strike',
   key: 'F',
   icon: '/icons/classes/rogue/kidneyshot.jpg',
+  autoFocus: false,
 };
 
 export default function castKidneyStrike({ playerId, globalSkillCooldown, isCasting, mana, getTargetPlayer, dispatch, sendToSocket, activateGlobalCooldown, startSkillCooldown, sounds }) {

--- a/client/next-js/skills/rogue/shadowLeap.js
+++ b/client/next-js/skills/rogue/shadowLeap.js
@@ -6,6 +6,7 @@ export const meta = {
   id: 'shadow-leap',
   key: 'Q',
   icon: '/icons/classes/rogue/shadowstep.jpg',
+  autoFocus: false,
 };
 
 export default function castShadowLeap({

--- a/client/next-js/utilities/index.ts
+++ b/client/next-js/utilities/index.ts
@@ -1,4 +1,9 @@
-import {Championship as ChampionshipType, Championship, Sponsor, Team} from "@/types";
+import {
+  Championship as ChampionshipType,
+  Championship,
+  Sponsor,
+  Team,
+} from "@/types";
 
 export const MIST_PER_SUI = 1000000000;
 
@@ -50,7 +55,6 @@ const mapTeam = (team: MoveTeam): Team => ({
   leadNickname: team.lead_nickname,
   teammateNicknames: team.teammate_nicknames,
 });
-
 
 const mapSponsor = (sponsor: MoveSponsor): Sponsor => ({
   address: sponsor.address,


### PR DESCRIPTION
## Summary
- add missing `autoFocus` metadata to Kidney Strike and Shadow Leap skills
- rename `utiltiies` folder to `utilities`
- update navbar import path after rename

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862a3cd69788329bc2b2aa80c3e6681