### PR TITLE
Fix paladin skill mana logic

### DIFF
--- a/client/next-js/skills/paladin/lightStrike.js
+++ b/client/next-js/skills/paladin/lightStrike.js
@@ -1,3 +1,5 @@
+import { SPELL_COST } from '../../consts';
+
 export const meta = {
   id: 'lightstrike',
   key: 'E',
@@ -5,8 +7,24 @@ export const meta = {
   autoFocus: false,
 };
 
-export default function castLightStrike({ globalSkillCooldown, isCasting, sendToSocket, activateGlobalCooldown, startSkillCooldown }) {
+export default function castLightStrike({
+  globalSkillCooldown,
+  isCasting,
+  mana,
+  sendToSocket,
+  activateGlobalCooldown,
+  startSkillCooldown,
+  sounds,
+}) {
   if (globalSkillCooldown || isCasting) return;
+  if (mana < SPELL_COST['lightstrike']) {
+    if (sounds?.noMana) {
+      sounds.noMana.currentTime = 0;
+      sounds.noMana.volume = 0.5;
+      sounds.noMana.play();
+    }
+    return;
+  }
   sendToSocket({ type: 'CAST_SPELL', payload: { type: 'lightstrike' } });
   activateGlobalCooldown();
   startSkillCooldown('lightstrike');

--- a/client/next-js/skills/paladin/lightWave.js
+++ b/client/next-js/skills/paladin/lightWave.js
@@ -1,5 +1,3 @@
-import { SPELL_COST } from '../../consts';
-
 export const meta = {
   id: 'lightwave',
   key: 'F',


### PR DESCRIPTION
## Summary
- add mana checks to `lightStrike`
- remove unused `SPELL_COST` import from `lightWave`

## Testing
- `node --check client/next-js/skills/paladin/lightStrike.js client/next-js/skills/paladin/lightWave.js`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862a3dc36b48329b2b59b670f307d5e