### PR TITLE
Add kill messages to chat

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -4120,17 +4120,29 @@ export function Game({models, sounds, textures, matchId, character}) {
                         }
                     }
                     break;
-                case "KILL":
-                    if (message.killerId === address) {
+                case "KILL": {
+                    const killer = players.get(message.killerId);
+                    const victim = players.get(message.victimId);
+                    const killerName = killer?.address || `Player ${message.killerId}`;
+                    const victimName = victim?.address || `Player ${message.victimId}`;
+
+                    dispatch({
+                        type: "SEND_CHAT_MESSAGE",
+                        payload: `${killerName} killed ${victimName}`,
+                    });
+
+                    if (message.killerId === myPlayerId) {
                         dispatch({
                             type: "SEND_CHAT_MESSAGE",
-                            payload: `+1 $MetaWars$ Gold for kill ${message?.character?.name}!`,
+                            payload: `+1 $MetaWars$ Gold for kill ${victimName}!`,
                         });
+                        dispatchEvent('player-kill');
                         setTimeout(() => {
                             refetchCoins();
                         }, 500);
                     }
                     break;
+                }
                 case "DAMAGE":
                     if (message.targetId) {
                         showDamage(message.targetId, message.amount, message.spellType);

--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -8,6 +8,7 @@ import {Buffs} from "../parts/Buffs";
 import {ComboPoints} from "../parts/ComboPoints";
 import {ExperienceBar} from "../parts/ExperienceBar";
 import {LevelUp} from "../parts/LevelUp";
+import {KillNotification} from "../parts/KillNotification";
 import {StatsModal} from "../parts/StatsModal";
 import {HowToPlayModal} from "../parts/HowToPlayModal";
 import {TargetHelpModal} from "../parts/TargetHelpModal";
@@ -152,6 +153,7 @@ export const Interface = () => {
             <CastBar/>
             <ExperienceBar />
             <LevelUp />
+            <KillNotification />
             <Chat />
         </div>
     )

--- a/client/next-js/components/parts/KillNotification.css
+++ b/client/next-js/components/parts/KillNotification.css
@@ -1,0 +1,33 @@
+.kill-overlay {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    z-index: 2000;
+}
+
+.kill-text {
+    font-size: 6rem;
+    font-weight: 800;
+    background: linear-gradient(45deg, #ffeb3b, #ff1744);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    text-shadow: 0 0 15px #fff, 0 0 25px #ff1744, 0 0 35px #ff1744;
+    animation: killAnim 2s ease-out forwards;
+}
+
+@keyframes killAnim {
+    0% {
+        transform: scale(0.5) rotate(-10deg);
+        opacity: 0;
+    }
+    50% {
+        transform: scale(1.6) rotate(10deg);
+        opacity: 1;
+    }
+    100% {
+        transform: scale(1) rotate(0deg);
+        opacity: 0;
+    }
+}

--- a/client/next-js/components/parts/KillNotification.jsx
+++ b/client/next-js/components/parts/KillNotification.jsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import "./KillNotification.css";
+
+export const KillNotification = () => {
+    const [visible, setVisible] = useState(false);
+
+    useEffect(() => {
+        const handler = () => {
+            setVisible(true);
+            setTimeout(() => setVisible(false), 3000);
+        };
+        window.addEventListener("player-kill", handler);
+        return () => window.removeEventListener("player-kill", handler);
+    }, []);
+
+    return (
+        <>
+            {visible && (
+                <div className="kill-overlay">
+                    <div className="kill-text">KILL!</div>
+                </div>
+            )}
+        </>
+    );
+};

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -440,6 +440,7 @@ function applyDamage(match, victimId, dealerId, damage, spellType) {
             broadcastToMatch(match.id, {
                 type: 'KILL',
                 killerId: dealerId,
+                victimId,
             });
             if (attacker.kills >= MAX_KILLS && !match.finished) {
                 finalizeMatch(match);


### PR DESCRIPTION
## Summary
- broadcast victim id for kills
- display killer and victim names in chat
- show gold reward and bigger animated kill text

## Testing
- `npx eslint -c client/next-js/.eslintrc.json components/game.jsx components/layout/Interface.tsx components/parts/KillNotification.jsx`
- `npx -y eslint@8 -c client/next-js/.eslintrc.json client/next-js/components/game.jsx client/next-js/components/layout/Interface.tsx client/next-js/components/parts/KillNotification.jsx`

------
https://chatgpt.com/codex/tasks/task_e_6862ac6c45948329a8b5acdfe37f5cc4