### PR TITLE
Adjust melee indicator and balance stats

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -289,36 +289,11 @@ export function Game({models, sounds, textures, matchId, character}) {
             const group = new THREE.Group();
             const start = Math.PI / 2 - MELEE_ANGLE / 2;
             const end = start + MELEE_ANGLE;
-            const cornerRadius = MELEE_RANGE_ATTACK * 0.04; // subtle rounding
-
-            const p0 = new THREE.Vector2(0, 0);
-            const p1 = new THREE.Vector2(Math.cos(start) * MELEE_RANGE_ATTACK, Math.sin(start) * MELEE_RANGE_ATTACK);
-            const p2 = new THREE.Vector2(Math.cos(end) * MELEE_RANGE_ATTACK, Math.sin(end) * MELEE_RANGE_ATTACK);
-
-            const off0To1 = p0.clone().add(p1.clone().sub(p0).normalize().multiplyScalar(cornerRadius));
-            const off1From0 = p1.clone().add(p0.clone().sub(p1).normalize().multiplyScalar(cornerRadius));
-            const off1To2 = p1.clone().add(p2.clone().sub(p1).normalize().multiplyScalar(cornerRadius));
-            const off2From1 = p2.clone().add(p1.clone().sub(p2).normalize().multiplyScalar(cornerRadius));
-            const off2To0 = p2.clone().add(p0.clone().sub(p2).normalize().multiplyScalar(cornerRadius));
-            const off0From2 = p0.clone().add(p2.clone().sub(p0).normalize().multiplyScalar(cornerRadius));
 
             const shape = new THREE.Shape();
-            shape.moveTo(off0To1.x, off0To1.y);
-            shape.lineTo(off1From0.x, off1From0.y);
-            shape.absarc(p1.x, p1.y, cornerRadius,
-                Math.atan2(off1From0.y - p1.y, off1From0.x - p1.x),
-                Math.atan2(off1To2.y - p1.y, off1To2.x - p1.x),
-                false);
-            shape.lineTo(off2From1.x, off2From1.y);
-            shape.absarc(p2.x, p2.y, cornerRadius,
-                Math.atan2(off2From1.y - p2.y, off2From1.x - p2.x),
-                Math.atan2(off2To0.y - p2.y, off2To0.x - p2.x),
-                false);
-            shape.lineTo(off0From2.x, off0From2.y);
-            shape.absarc(p0.x, p0.y, cornerRadius,
-                Math.atan2(off0From2.y - p0.y, off0From2.x - p0.x),
-                Math.atan2(off0To1.y - p0.y, off0To1.x - p0.x),
-                false);
+            shape.moveTo(0, 0);
+            shape.lineTo(Math.cos(start) * MELEE_RANGE_ATTACK, Math.sin(start) * MELEE_RANGE_ATTACK);
+            shape.lineTo(Math.cos(end) * MELEE_RANGE_ATTACK, Math.sin(end) * MELEE_RANGE_ATTACK);
             shape.closePath();
 
             const geo = new THREE.ShapeGeometry(shape);
@@ -912,7 +887,7 @@ export function Game({models, sounds, textures, matchId, character}) {
         const LIGHTWAVE_DAMAGE = 40;
         const STUN_SPIN_SPEED = 2;
         const FEAR_SPIN_SPEED = 1.5;
-        const BLADESTORM_DAMAGE = 40;
+        const BLADESTORM_DAMAGE = 32;
 
         // Медленнее пускаем сферы как настоящие заклинания
         const MIN_SPHERE_IMPULSE = 6;
@@ -2829,7 +2804,7 @@ export function Game({models, sounds, textures, matchId, character}) {
         }
 
 
-        function applyDamageRuneEffect(playerId, duration = 60000) {
+        function applyDamageRuneEffect(playerId, duration = 50000) {
             const existing = activeDamageEffects.get(playerId);
             if (existing) {
                 existing.parent?.remove(existing);

--- a/client/next-js/consts/classStats.json
+++ b/client/next-js/consts/classStats.json
@@ -1,7 +1,7 @@
 {
-  "mage": { "hp": 100, "armor": 20 },
-  "warlock": { "hp": 110, "armor": 25 },
-  "paladin": { "hp": 150, "armor": 40 },
-  "rogue": { "hp": 120, "armor": 30 },
-  "warrior": { "hp": 160, "armor": 50 }
+  "mage": { "hp": 130, "armor": 20 },
+  "warlock": { "hp": 143, "armor": 25 },
+  "paladin": { "hp": 195, "armor": 40 },
+  "rogue": { "hp": 156, "armor": 30 },
+  "warrior": { "hp": 208, "armor": 50 }
 }

--- a/client/next-js/consts/index.ts
+++ b/client/next-js/consts/index.ts
@@ -6,7 +6,7 @@ export const NETWORK = process.env.NEXT_PUBLIC_NETWORK as
 export const TREASURY_CAP_ID = process.env.NEXT_PUBLIC_TREASURY_CAP_ID;
 
 // Base health for players. Used for health bar calculations on both client and server
-export const MAX_HP = 120;
+export const MAX_HP = 156;
 export const MAX_MANA = 130;
 // Amount of experience required for each level
 export const XP_PER_LEVEL = 1000;

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -5,13 +5,13 @@ const http = require('http');
 const { createProfile } = require('./sui.cjs');
 
 const UPDATE_MATCH_INTERVAL = 33;
-const MAX_HP = 120;
+const MAX_HP = 156;
 const MAX_MANA = 130;
 const MAX_KILLS = 15;
 const XP_PER_LEVEL = 1000;
 const MANA_REGEN_INTERVAL = 1000;
 const MANA_REGEN_AMOUNT = 1.3; // 30% faster mana regeneration
-const HP_REGEN_AMOUNT = 0.8; // Basic health regeneration per tick
+const HP_REGEN_AMOUNT = 0.4; // Basic health regeneration per tick (reduced)
 const SPELL_COST = require('../client/next-js/consts/spellCosts.json');
 const ICEBALL_ICON = '/icons/spell_frostbolt.jpg';
 const FROSTNOVA_ICON = '/icons/frostnova.jpg';
@@ -23,7 +23,7 @@ const CLASS_STATS = require('../client/next-js/consts/classStats.json');
 const ADRENALINE_RUSH_ICON = '/icons/classes/rogue/adrenalinerush.jpg';
 const MELEE_RANGE = 2.125;
 const LIGHTSTRIKE_DAMAGE = 41; // increased by 20%
-const BLADESTORM_DAMAGE = 40;
+const BLADESTORM_DAMAGE = 32;
 
 function withinMeleeRange(a, b) {
     if (!a || !b) return false;
@@ -331,7 +331,7 @@ function checkRunePickup(match, playerId) {
                     player.buffs.push({
                         type: 'damage',
                         percent: 0.4,
-                        expires: Date.now() + 60000,
+                        expires: Date.now() + 50000,
                         icon: '/icons/rune_power.jpg'
                     });
                     break;


### PR DESCRIPTION
## Summary
- simplify melee indicator to a plain triangle
- reduce damage rune duration to 50s
- halve HP regeneration rate
- boost all base HP by 30%
- lower Bladestorm damage

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_68639824b3788329a2764b490286f621