### PR TITLE
Adjust power rune effect

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -2805,7 +2805,7 @@ export function Game({models, sounds, textures, matchId, character}) {
         }
 
 
-        function applyDamageRuneEffect(playerId, duration = 50000) {
+        function applyDamageRuneEffect(playerId, duration = 15000) {
             const existing = activeDamageEffects.get(playerId);
             if (existing) {
                 existing.parent?.remove(existing);

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -330,8 +330,8 @@ function checkRunePickup(match, playerId) {
                 case 'damage':
                     player.buffs.push({
                         type: 'damage',
-                        percent: 0.4,
-                        expires: Date.now() + 50000,
+                        percent: 0.1,
+                        expires: Date.now() + 15000,
                         icon: '/icons/rune_power.jpg'
                     });
                     break;


### PR DESCRIPTION
## Summary
- shorten damage rune effect duration to 15 seconds
- reduce damage bonus from the rune to 10%

## Testing
- `npm test --prefix server` *(fails: no test specified)*
- `npm run lint --prefix client/next-js` *(fails due to missing eslint-plugin-react)*
- `npm test --prefix client/next-js` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863afdbd0788329aabc313c300b8efa