### PR TITLE
Fix melee indicator range

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -888,7 +888,7 @@ export function Game({models, sounds, textures, matchId, character}) {
         // Keep in sync with server constant MELEE_RANGE
         const MELEE_RANGE_ATTACK = 2.125; // melee range
         // Slightly extend the visual indicator so it matches perceived reach
-        const MELEE_INDICATOR_RANGE = MELEE_RANGE_ATTACK * 1.1;
+        const MELEE_INDICATOR_RANGE = MELEE_RANGE_ATTACK * 1.3;
         // Melee arc in radians (~132 degrees)
         const MELEE_ANGLE = (132 * Math.PI) / 180;
         const LIGHTWAVE_DAMAGE = 40;


### PR DESCRIPTION
## Summary
- extend melee range indicator constant so Warrior E ability range matches the visualization

## Testing
- `npx -y eslint@8 -c .eslintrc.json components/game.jsx --ext .jsx`

------
https://chatgpt.com/codex/tasks/task_e_6863b6c3bda88329b2c100ec1946d7c9