### PR TITLE
Adjust modals

### DIFF
--- a/client/next-js/components/parts/HowToPlayModal.jsx
+++ b/client/next-js/components/parts/HowToPlayModal.jsx
@@ -2,12 +2,10 @@ import { useEffect, useState, useCallback } from "react";
 import {
   Modal as HeroModal,
   ModalContent,
-  ModalHeader,
   ModalBody,
-  ModalFooter,
-  Button,
   useDisclosure,
 } from "@heroui/react";
+import { ConnectionButton } from "@/components/connection-button";
 
 const STORAGE_KEY = 'hideHowToPlay';
 
@@ -25,23 +23,24 @@ export const HowToPlayModal = () => {
     setOpen(false);
   }, []);
 
-  const dontShowAgain = () => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem(STORAGE_KEY, 'true');
-    }
-    setOpen(false);
-  };
 
   useEffect(() => {
     if (!open) return;
-    const handler = (e) => {
+    const keyHandler = (e) => {
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         close();
       }
     };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
+    const clickHandler = () => {
+      close();
+    };
+    window.addEventListener('keydown', keyHandler);
+    window.addEventListener('mousedown', clickHandler);
+    return () => {
+      window.removeEventListener('keydown', keyHandler);
+      window.removeEventListener('mousedown', clickHandler);
+    };
   }, [open, close]);
 
   const { isOpen } = useDisclosure({ isOpen: open });
@@ -52,20 +51,9 @@ export const HowToPlayModal = () => {
     <HeroModal isOpen={isOpen} size="md" onOpenChange={() => setOpen(false)}>
       <ModalContent>
         {() => (
-          <>
-            <ModalHeader>How to Play</ModalHeader>
-            <ModalBody>
-              <div style={{ width: 400, height: 300 }} className="flex items-center justify-center">
-                <img src="/images/how-to-play.webp" alt="How to play" className="max-w-full max-h-full" />
-              </div>
-            </ModalBody>
-            <ModalFooter>
-              <Button color="primary" onPress={dontShowAgain}>Don't show again</Button>
-              <Button color="danger" variant="light" onPress={close}>
-                Close (Enter or Space)
-              </Button>
-            </ModalFooter>
-          </>
+          <ModalBody className="flex items-center justify-center">
+            <ConnectionButton text="Connect" className="m-auto" />
+          </ModalBody>
         )}
       </ModalContent>
     </HeroModal>

--- a/client/next-js/components/parts/TargetHelpModal.jsx
+++ b/client/next-js/components/parts/TargetHelpModal.jsx
@@ -26,14 +26,21 @@ export const TargetHelpModal = () => {
 
   useEffect(() => {
     if (!open) return;
-    const handler = (e) => {
+    const keyHandler = (e) => {
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         close();
       }
     };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
+    const clickHandler = () => {
+      close();
+    };
+    window.addEventListener('keydown', keyHandler);
+    window.addEventListener('mousedown', clickHandler);
+    return () => {
+      window.removeEventListener('keydown', keyHandler);
+      window.removeEventListener('mousedown', clickHandler);
+    };
   }, [open, close]);
 
   if (!open) return null;


### PR DESCRIPTION
## Summary
- close help modals when clicking anywhere
- simplify HowToPlay modal to show only a connection button

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_6863ba4fcbbc8329a05572a6dad08b42