### PR TITLE
Fix eviscerate damage and melee indicator

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -292,11 +292,7 @@ export function Game({models, sounds, textures, matchId, character}) {
         };
 
         const createMeleeIndicator = () => {
-            const geometry = new THREE.RingGeometry(
-                Math.max(MELEE_INDICATOR_RANGE - 0.1, 0),
-                MELEE_INDICATOR_RANGE,
-                32,
-            );
+            const geometry = new THREE.CircleGeometry(MELEE_INDICATOR_RANGE, 32);
             const material = new THREE.MeshBasicMaterial({
                 color: 0xffff00,
                 transparent: true,

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -908,10 +908,10 @@ ws.on('connection', (socket) => {
                         if (message.payload.type === 'eviscerate' && message.payload.targetId) {
                             const target = match.players.get(message.payload.targetId);
                             if (target && withinMeleeRange(player, target)) {
-                                const damage = 28 * (player.comboPoints || 0);
-                                if (damage > 0) {
-                                    applyDamage(match, target.id, id, damage, 'eviscerate');
-                                }
+                                const base = 28;
+                                const combo = player.comboPoints || 0;
+                                const damage = base * Math.max(combo, 1);
+                                applyDamage(match, target.id, id, damage, 'eviscerate');
                             }
                             if (target) {
                                 player.comboPoints = 0;


### PR DESCRIPTION
## Summary
- make the melee range indicator a filled circle
- ensure eviscerate always deals damage and scales with combo points

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_686421f0f47083298c2bb5090fd13f98