### PR TITLE
Show melee indicator ring and nerf melee damage

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -292,7 +292,14 @@ export function Game({models, sounds, textures, matchId, character}) {
         };
 
         const createMeleeIndicator = () => {
-            const geometry = new THREE.CircleGeometry(MELEE_INDICATOR_RANGE, 32);
+            const geometry = new THREE.RingGeometry(
+                MELEE_INDICATOR_RANGE * 0.95,
+                MELEE_INDICATOR_RANGE,
+                32,
+                1,
+                Math.PI / 2 - MELEE_ANGLE / 2,
+                MELEE_ANGLE,
+            );
             const material = new THREE.MeshBasicMaterial({
                 color: 0xffff00,
                 transparent: true,
@@ -872,7 +879,7 @@ export function Game({models, sounds, textures, matchId, character}) {
         const FROSTNOVA_RANGE = FIREBLAST_RANGE / 4;
         const FROSTNOVA_RING_DURATION = 1000; // ms
         const LIGHTWAVE_RING_DURATION = 1000; // ms
-        const LIGHTSTRIKE_DAMAGE = 41; // 20% more damage for warrior/paladin/rogue E
+        const LIGHTSTRIKE_DAMAGE = 35; // reduced by 15%
         // Melee range for auto attacks and melee abilities
         // Keep in sync with server constant MELEE_RANGE
         const MELEE_RANGE_ATTACK = 2.125; // melee range

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -23,7 +23,7 @@ const CLASS_STATS = require('../client/next-js/consts/classStats.json');
 const ADRENALINE_RUSH_ICON = '/icons/classes/rogue/adrenalinerush.jpg';
 const RAGE_ICON = '/icons/classes/warrior/rage.jpg';
 const MELEE_RANGE = 2.125;
-const LIGHTSTRIKE_DAMAGE = 41; // increased by 20%
+const LIGHTSTRIKE_DAMAGE = 35; // reduced by 15%
 const BLADESTORM_DAMAGE = 32;
 
 function withinMeleeRange(a, b) {


### PR DESCRIPTION
## Summary
- render melee range indicator using a ring arc based on `MELEE_ANGLE`
- reduce `LIGHTSTRIKE_DAMAGE` by 15% on both client and server

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*


------
https://chatgpt.com/codex/tasks/task_e_686434ef96f4832988aa26465a87fe2d