### PR TITLE
Restore HowToPlay modal with instructions image

### DIFF
--- a/client/next-js/components/parts/HowToPlayModal.jsx
+++ b/client/next-js/components/parts/HowToPlayModal.jsx
@@ -2,10 +2,12 @@ import { useEffect, useState, useCallback } from "react";
 import {
   Modal as HeroModal,
   ModalContent,
+  ModalHeader,
   ModalBody,
+  ModalFooter,
+  Button,
   useDisclosure,
 } from "@heroui/react";
-import { ConnectionButton } from "@/components/connection-button";
 
 const STORAGE_KEY = 'hideHowToPlay';
 
@@ -23,24 +25,23 @@ export const HowToPlayModal = () => {
     setOpen(false);
   }, []);
 
+  const dontShowAgain = () => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(STORAGE_KEY, 'true');
+    }
+    setOpen(false);
+  };
 
   useEffect(() => {
     if (!open) return;
-    const keyHandler = (e) => {
+    const handler = (e) => {
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         close();
       }
     };
-    const clickHandler = () => {
-      close();
-    };
-    window.addEventListener('keydown', keyHandler);
-    window.addEventListener('mousedown', clickHandler);
-    return () => {
-      window.removeEventListener('keydown', keyHandler);
-      window.removeEventListener('mousedown', clickHandler);
-    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
   }, [open, close]);
 
   const { isOpen } = useDisclosure({ isOpen: open });
@@ -51,9 +52,20 @@ export const HowToPlayModal = () => {
     <HeroModal isOpen={isOpen} size="md" onOpenChange={() => setOpen(false)}>
       <ModalContent>
         {() => (
-          <ModalBody className="flex items-center justify-center">
-            <ConnectionButton text="Connect" className="m-auto" />
-          </ModalBody>
+          <>
+            <ModalHeader>How to Play</ModalHeader>
+            <ModalBody>
+              <div style={{ width: 400, height: 300 }} className="flex items-center justify-center">
+                <img src="/images/how-to-play.webp" alt="How to play" className="max-w-full max-h-full" />
+              </div>
+            </ModalBody>
+            <ModalFooter>
+              <Button color="primary" onPress={dontShowAgain}>Don't show again</Button>
+              <Button color="danger" variant="light" onPress={close}>
+                Close (Enter or Space)
+              </Button>
+            </ModalFooter>
+          </>
         )}
       </ModalContent>
     </HeroModal>


### PR DESCRIPTION
## Summary
- show the original how-to-play instructions image in the modal
- re-add close and "don't show again" buttons for the HowToPlay modal

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find plugin "eslint-plugin-react")*
- `npm test` in `server` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6864411b94f88329811db4c4e3d248dd