### PR TITLE
Update melee indicator appearance

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -292,11 +292,9 @@ export function Game({models, sounds, textures, matchId, character}) {
         };
 
         const createMeleeIndicator = () => {
-            const geometry = new THREE.RingGeometry(
-                MELEE_INDICATOR_RANGE * 0.95,
+            const geometry = new THREE.CircleGeometry(
                 MELEE_INDICATOR_RANGE,
                 32,
-                1,
                 Math.PI / 2 - MELEE_ANGLE / 2,
                 MELEE_ANGLE,
             );


### PR DESCRIPTION
## Summary
- make the melee attack indicator filled instead of a hollow ring

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6864435a31a08329846050d1b53a8362