### PR TITLE
Fix remote animation loop

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -2513,11 +2513,15 @@ export function Game({models, sounds, textures, matchId, character}) {
             }
 
             // Attach an event listener for when the animation ends
-            if (loop === THREE.LoopOnce && onEnd) {
+            if (loop === THREE.LoopOnce) {
                 const onAnimationEnd = (event) => {
                     if (event.action === action) {
                         mixer.removeEventListener("finished", onAnimationEnd); // Clean up listener
-                        onEnd(event);
+                        if (onEnd) {
+                            onEnd(event);
+                        } else {
+                            setAnimation("idle");
+                        }
                     }
                 };
 


### PR DESCRIPTION
## Summary
- stop other players repeating one-shot animations by switching back to `idle` when an animation finishes

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*

------
https://chatgpt.com/codex/tasks/task_e_6864cc895358832992bd2479b2343f98