### PR TITLE
Fix warrior melee cone and damage rounding

### DIFF
--- a/server/melee.cjs
+++ b/server/melee.cjs
@@ -12,13 +12,19 @@ function withinMeleeRange(a, b) {
 
 function withinMeleeCone(a, b) {
     if (!withinMeleeRange(a, b)) return false;
-    const angleToTarget = Math.atan2(
-        b.position.x - a.position.x,
-        b.position.z - a.position.z
-    );
-    let diff = Math.abs(angleToTarget - (a.rotation?.y || 0));
-    if (diff > Math.PI) diff = Math.abs(diff - 2 * Math.PI);
-    return diff < MELEE_ANGLE;
+    const dx = b.position.x - a.position.x;
+    const dy = b.position.y - a.position.y;
+    const dz = b.position.z - a.position.z;
+    const forward = {
+        x: Math.sin(a.rotation?.y || 0),
+        y: 0,
+        z: Math.cos(a.rotation?.y || 0),
+    };
+    const len = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    if (!len) return true;
+    const dot = forward.x * dx + forward.y * dy + forward.z * dz;
+    const angle = Math.acos(dot / len);
+    return angle < MELEE_ANGLE;
 }
 
 module.exports = {

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -439,6 +439,7 @@ function applyDamage(match, victimId, dealerId, damage, spellType) {
 
     const reduction = victim.armor / 200; // 100 armor = 50% damage reduction
     totalDamage = totalDamage * Math.max(0, 1 - reduction);
+    totalDamage = Math.round(totalDamage);
     victim.hp = Math.max(0, victim.hp - totalDamage);
     if (victim.hp <= 0) {
         victim.deaths++;


### PR DESCRIPTION
## Summary
- align server-side melee cone check with client by using a 3D vector angle check
- round total damage before applying it

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6864d45155f0832985909ab6bda5d5e0