### PR TITLE
Fix melee indicator opacity bug

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -2451,9 +2451,18 @@ export function Game({models, sounds, textures, matchId, character}) {
                 model.traverse((obj) => {
                     if (obj.isMesh) {
                         applyToMaterials(obj, (mat) => {
+                            gsap.killTweensOf(mat);
                             mat.transparent = true;
                             mat.opacity = 0;
-                            gsap.to(mat, { opacity: 1, duration: fadeDuration });
+                            const targetOpacity =
+                                meleeRangeIndicator && obj === meleeRangeIndicator
+                                    ? MELEE_INDICATOR_OPACITY
+                                    : 1;
+                            gsap.to(mat, {
+                                opacity: targetOpacity,
+                                duration: fadeDuration,
+                                overwrite: true,
+                            });
                         });
                     }
                 });
@@ -2461,8 +2470,13 @@ export function Game({models, sounds, textures, matchId, character}) {
                 model.traverse((obj) => {
                     if (obj.isMesh) {
                         applyToMaterials(obj, (mat) => {
+                            gsap.killTweensOf(mat);
                             mat.transparent = true;
-                            gsap.to(mat, { opacity: 0, duration: fadeDuration });
+                            gsap.to(mat, {
+                                opacity: 0,
+                                duration: fadeDuration,
+                                overwrite: true,
+                            });
                         });
                     }
                 });


### PR DESCRIPTION
## Summary
- prevent GSAP tween overlap when fading player model
- always kill existing tweens before adjusting material opacity

## Testing
- `npm run lint` *(fails: package.json missing)*
- `npm run lint` in `server` *(fails: missing script)*
- `npm test` in `server` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6864e695a94083299064f625292739d1