### PR TITLE
Slow down player movement by 15%

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -2389,9 +2389,9 @@ export function Game({models, sounds, textures, matchId, character}) {
             if (!controlsEnabled || debuffsRef.current.some(d => d.type === 'stun')) return;
             const model = players.get(myPlayerId).model;
             // Adjust walking and running speed
-            const baseWalkSpeed = 7.2; // Increased running speed by 20%
+            const baseWalkSpeed = 6.12; // Reduced running speed by 15%
             const speedDelta =
-                deltaTime * (playerOnFloor ? baseWalkSpeed : 5) * movementSpeedModifier; // Apply speed modifier
+                deltaTime * (playerOnFloor ? baseWalkSpeed : 4.25) * movementSpeedModifier; // Apply speed modifier
 
             // Rotate playerVelocity when pressing A or D
             if (keyStates["KeyA"]) {


### PR DESCRIPTION
## Summary
- reduce base walking speed so everyone moves 15% slower

## Testing
- `npx -y eslint@8 -c .eslintrc.json . --ext .ts,.tsx`

------
https://chatgpt.com/codex/tasks/task_e_686597fe39288329af15d5a172b6eb72