### PR TITLE
Add rank points display

### DIFF
--- a/client/next-js/app/play/page.tsx
+++ b/client/next-js/app/play/page.tsx
@@ -19,12 +19,14 @@ import { ConnectionButton } from "@/components/connection-button";
 import { ProfileForm } from "@/components/profile-form";
 import { useProfile } from "@/hooks";
 import { useRatings } from "@/hooks/useRatings";
+import { useRankTable } from "@/hooks/useRankTable";
 
 export default function MatchesPage() {
   const router = useRouter();
   const account = useCurrentAccount();
   const { profile, refetch } = useProfile();
   const { ratings } = useRatings();
+  const { table: rankTable } = useRankTable();
 
   return (
     <div className="h-full w-full  items-center justify-center">
@@ -80,6 +82,23 @@ export default function MatchesPage() {
                       <TableRow key={r.address}>
                         <TableCell>{idx + 1}</TableCell>
                         <TableCell>{r.address}</TableCell>
+                        <TableCell>{r.points}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </Card>
+              <Card className="w-full max-w-xl mx-32 mt-4 p-4 space-y-2">
+                <h4 className="font-bold text-large">Rank Points</h4>
+                <Table aria-label="rank-points">
+                  <TableHeader>
+                    <TableColumn>Place</TableColumn>
+                    <TableColumn>Points</TableColumn>
+                  </TableHeader>
+                  <TableBody>
+                    {rankTable.map((r) => (
+                      <TableRow key={r.position}>
+                        <TableCell>{r.position}</TableCell>
                         <TableCell>{r.points}</TableCell>
                       </TableRow>
                     ))}

--- a/client/next-js/hooks/index.js
+++ b/client/next-js/hooks/index.js
@@ -4,3 +4,4 @@ export * from "./useRatings";
 export * from "./useItems";
 export * from "./useDao";
 export * from "./useProfile";
+export * from "./useRankTable";

--- a/client/next-js/hooks/useRankTable.ts
+++ b/client/next-js/hooks/useRankTable.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { useWS } from "./useWS";
+
+export interface RankEntry {
+  position: number;
+  points: number;
+}
+
+export const useRankTable = () => {
+  const [table, setTable] = useState<RankEntry[]>([]);
+  const { socket, sendToSocket } = useWS();
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      let message: any = {};
+      try {
+        message = JSON.parse(event.data);
+      } catch (e) {
+        return;
+      }
+
+      if (message.type === "RANK_POINTS" && Array.isArray(message.table)) {
+        setTable(
+          message.table.map(([pos, pts]: [number, number]) => ({
+            position: pos,
+            points: pts,
+          }))
+        );
+      }
+    };
+
+    const handleOpen = () => {
+      sendToSocket({ type: "GET_RANK_POINTS" });
+    };
+
+    socket.addEventListener("message", handleMessage);
+    if (socket.readyState === WebSocket.OPEN) {
+      sendToSocket({ type: "GET_RANK_POINTS" });
+    } else {
+      socket.addEventListener("open", handleOpen);
+    }
+
+    return () => {
+      socket.removeEventListener("message", handleMessage);
+      socket.removeEventListener("open", handleOpen);
+    };
+  }, []);
+
+  return { table };
+};


### PR DESCRIPTION
## Summary
- expose rank points table from the server via new `GET_RANK_POINTS` message
- hook to retrieve this table on the client
- show rank points table on the Play page

## Testing
- `npm test` *(fails: package.json missing at repo root)*
- `cd server && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866734663748329815bedf597839d35