### PR TITLE
Use assetUrl for all asset paths

### DIFF
--- a/client/next-js/app/matches/[id]/page.tsx
+++ b/client/next-js/app/matches/[id]/page.tsx
@@ -2,6 +2,7 @@
 import {useWS} from "@/hooks/useWS";
 import {useCallback, useEffect, useMemo, useState} from "react";
 import Image from "next/image";
+import { assetUrl } from "@/utilities/assets";
 import {Button, Table, TableHeader, TableColumn, TableBody, TableRow, TableCell} from "@heroui/react";
 import {Modal, ModalContent, ModalHeader, ModalBody, ModalFooter} from "@heroui/modal";
 import {Kbd} from "@heroui/kbd";
@@ -46,7 +47,7 @@ export default function MatchesPage() {
     const classOptions = {
         warrior: {
             label: 'Warrior',
-            icon:  '/icons/warrior.webp',
+            icon:  assetUrl('/icons/warrior.webp'),
             type: 'Melee',
             description: 'Brutal melee fighter with unmatched strength.',
             skills: [
@@ -60,7 +61,7 @@ export default function MatchesPage() {
         },
         paladin: {
             label: 'Paladin',
-            icon: '/icons/paladin.webp',
+            icon: assetUrl('/icons/paladin.webp'),
             type: 'Melee',
             description: 'Holy warrior empowered by light.',
             skills: [
@@ -74,7 +75,7 @@ export default function MatchesPage() {
         },
         rogue: {
             label: 'Rogue',
-            icon:  '/icons/rogue.webp',
+            icon:  assetUrl('/icons/rogue.webp'),
             type: 'Melee',
             description: 'Stealthy assassin striking from shadows.',
             skills: [
@@ -88,7 +89,7 @@ export default function MatchesPage() {
         },
         warlock: {
             label: 'Warlock',
-            icon: '/icons/warlock.webp',
+            icon: assetUrl('/icons/warlock.webp'),
             type: 'Ranged',
             description: 'Manipulator of dark magic.',
             skills: [
@@ -102,7 +103,7 @@ export default function MatchesPage() {
         },
         mage: {
             label: 'Mage',
-            icon: '/icons/mage.png',
+            icon: assetUrl('/icons/mage.png'),
             type: 'Ranged',
             description: 'Master of arcane magic and spells.',
             skills: [

--- a/client/next-js/app/play/page.tsx
+++ b/client/next-js/app/play/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { assetUrl } from "@/utilities/assets";
 import {
   Card,
   CardHeader,
@@ -48,7 +49,7 @@ export default function MatchesPage() {
                     alt="Open World"
                     className="w-full h-full object-cover rounded-t-lg"
                     height={1200}
-                    src="/images/open-world.jpg"
+                    src={assetUrl('/images/open-world.jpg')}
                     width={2000}
                   />
                 </Card>
@@ -64,7 +65,7 @@ export default function MatchesPage() {
                     alt="Arena Match"
                     className="w-full h-full object-cover rounded-t-lg"
                     height={1200}
-                    src="/images/battle.jpg"
+                    src={assetUrl('/images/battle.jpg')}
                     width={2000}
                   />
                 </Card>
@@ -115,7 +116,7 @@ export default function MatchesPage() {
               alt="Arena Match"
               className="w-full h-full absolute object-cover rounded-t-lg"
               height={1400}
-              src="/images/tower_bg.png"
+              src={assetUrl('/images/tower_bg.png')}
               width={3000}
             />
             <ConnectionButton className="m-auto" text="Connect to Play" />

--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -388,7 +388,7 @@ export function Game({models, sounds, textures, matchId, character}) {
         const activeSlowEffects = new Map(); // key = playerId -> {mesh, timeout}
         const activeSprintTrails = new Map(); // key = playerId -> {mesh, start, duration, timeout}
         const activeBladestorms = new Map(); // key = playerId -> {start, duration, sound}
-        const fearTexture = new THREE.TextureLoader().load('/icons/classes/warlock/possession.jpg');
+        const fearTexture = new THREE.TextureLoader().load(assetUrl('/icons/classes/warlock/possession.jpg'));
 
         const glowTexture = (() => {
             const size = 64;
@@ -1469,7 +1469,7 @@ export function Game({models, sounds, textures, matchId, character}) {
         function highlightCrosshair() {
             if (!targetImage) return;
             if (!isFocused) {
-                targetImage.src = '/icons/target.svg';
+                targetImage.src = assetUrl('/icons/target.svg');
                 return;
             }
             const id = getTargetPlayer();
@@ -1481,12 +1481,12 @@ export function Game({models, sounds, textures, matchId, character}) {
                 const targetPos = players.get(id).model.position.clone();
                 const dist = start.distanceTo(targetPos);
                 if (dist <= FIREBLAST_RANGE) {
-                    targetImage.src = '/icons/target-green.svg';
+                    targetImage.src = assetUrl('/icons/target-green.svg');
                 } else {
-                    targetImage.src = '/icons/target.svg';
+                    targetImage.src = assetUrl('/icons/target.svg');
                 }
             } else {
-                targetImage.src = '/icons/target.svg';
+                targetImage.src = assetUrl('/icons/target.svg');
             }
         }
 

--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -18,6 +18,7 @@ import {CLASS_ICONS} from "@/consts/classes";
 
 import './Interface.css';
 import Image from "next/image";
+import { assetUrl } from "@/utilities/assets";
 import React, {useEffect, useState} from "react";
 import {MAX_HP, MAX_MANA} from "../../consts";
 
@@ -135,7 +136,7 @@ export const Interface = () => {
                     alt="Target"
                     width={25}
                     height={25}
-                    src="/icons/target.svg"
+                    src={assetUrl('/icons/target.svg')}
                 />
             </div>
 

--- a/client/next-js/components/parts/Buffs.jsx
+++ b/client/next-js/components/parts/Buffs.jsx
@@ -1,5 +1,6 @@
 import {useInterface} from '@/context/inteface';
 import {useEffect, useState} from 'react';
+import { assetUrl } from '../../utilities/assets';
 import './Buffs.css';
 
 /**
@@ -45,7 +46,7 @@ export const Buffs = (
         const timeLeft = getRemaining(item);
         return (
             <div key={`${type}-${idx}`} className="buff-icon">
-                <img src={item.icon || '/icons/shield.png'} alt={item.type} />
+                <img src={item.icon || assetUrl('/icons/shield.png')} alt={item.type} />
                 {item.stacks && <span className="stack-count">{item.stacks}</span>}
                 {timeLeft > 0 && <span className="time">{formatTime(timeLeft)}</span>}
             </div>

--- a/client/next-js/components/parts/ComboPoints.jsx
+++ b/client/next-js/components/parts/ComboPoints.jsx
@@ -1,5 +1,6 @@
 import { useInterface } from '@/context/inteface';
 import Image from 'next/image';
+import { assetUrl } from '../../utilities/assets';
 import './ComboPoints.css';
 
 export const ComboPoints = () => {
@@ -12,7 +13,7 @@ export const ComboPoints = () => {
             {Array.from({ length: 5 }).map((_, idx) => (
                 <Image
                     key={idx}
-                    src="/icons/classes/rogue/combo_point.jpg"
+                    src={assetUrl('/icons/classes/rogue/combo_point.jpg')}
                     alt="Combo Point"
                     width={24}
                     height={24}

--- a/client/next-js/components/parts/HowToPlayModal.jsx
+++ b/client/next-js/components/parts/HowToPlayModal.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
+import { assetUrl } from "../../utilities/assets";
 import {
   Modal as HeroModal,
   ModalContent,
@@ -56,7 +57,7 @@ export const HowToPlayModal = () => {
             <ModalHeader>How to Play</ModalHeader>
             <ModalBody>
               <div style={{ width: 400, height: 300 }} className="flex items-center justify-center">
-                <img src="/images/how-to-play.webp" alt="How to play" className="max-w-full max-h-full" />
+                <img src={assetUrl('/images/how-to-play.webp')} alt="How to play" className="max-w-full max-h-full" />
               </div>
             </ModalBody>
             <ModalFooter>

--- a/client/next-js/components/parts/TargetHelpModal.jsx
+++ b/client/next-js/components/parts/TargetHelpModal.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
+import { assetUrl } from "../../utilities/assets";
 import "./TargetHelpModal.css";
 
 const STORAGE_KEY = 'hideTargetHelp';
@@ -49,7 +50,7 @@ export const TargetHelpModal = () => {
     <div className="target-help-overlay">
       <h2 className="target-help-title">Target Help</h2>
       <div className="target-help-body">
-        <img src="/icons/target-green.svg" alt="Target Help" className="target-help-image" />
+        <img src={assetUrl('/icons/target-green.svg')} alt="Target Help" className="target-help-image" />
       </div>
       <div className="target-help-actions">
         <button className="target-help-button" onClick={dontShowAgain}>Don't show again</button>

--- a/client/next-js/consts/classes.ts
+++ b/client/next-js/consts/classes.ts
@@ -1,7 +1,9 @@
+import { assetUrl } from "@/utilities/assets";
+
 export const CLASS_ICONS: Record<string, string> = {
-  mage: "/icons/mage.png",
-  warlock: "/icons/warlock.webp",
-  paladin: "/icons/paladin.webp",
-  rogue: "/icons/rogue.webp",
-  warrior: "/icons/warrior.webp",
+  mage: assetUrl("/icons/mage.png"),
+  warlock: assetUrl("/icons/warlock.webp"),
+  paladin: assetUrl("/icons/paladin.webp"),
+  rogue: assetUrl("/icons/rogue.webp"),
+  warrior: assetUrl("/icons/warrior.webp"),
 };

--- a/client/next-js/skills/mage/frostNova.js
+++ b/client/next-js/skills/mage/frostNova.js
@@ -1,9 +1,10 @@
 import { SPELL_COST } from "../../consts";
+import { assetUrl } from "../../utilities/assets";
 
 export const meta = {
   id: "frostnova",
   key: "Q",
-  icon: "/icons/classes/mage/frostnova.jpg",
+  icon: assetUrl('/icons/classes/mage/frostnova.jpg'),
   autoFocus: false,
 };
 


### PR DESCRIPTION
## Summary
- import and use `assetUrl` when referencing assets
- update icons and images across the UI to use `assetUrl`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68678c69981c8329b4374b4fcffcf7d0