### PR TITLE
Add cooldown completion animation

### DIFF
--- a/client/next-js/components/parts/SkillBar.css
+++ b/client/next-js/components/parts/SkillBar.css
@@ -77,3 +77,22 @@
     line-height: 1;
     pointer-events: none;
 }
+
+.skill-button.ready .skill-icon {
+    animation: skill-ready 0.4s ease-out;
+}
+
+@keyframes skill-ready {
+    0% {
+        transform: scale(1);
+        box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.8);
+    }
+    50% {
+        transform: scale(1.15);
+        box-shadow: 0 0 10px 5px rgba(255, 255, 255, 0.8);
+    }
+    100% {
+        transform: scale(1);
+        box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
+    }
+}


### PR DESCRIPTION
## Summary
- highlight skill icon when cooldown ends with new animation class
- trigger ready animation in SkillBar when cooldown finishes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686796adc2a48329b0a43857c6222924