### PR TITLE
Add berserk buff effects

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -1877,6 +1877,9 @@ export function Game({models, sounds, textures, matchId, character}) {
                         igniteHands,
                         sounds,
                     });
+                    applySpeedEffect(playerId, 6000, 1.5);
+                    applyFreedomEffect(playerId, 6000);
+                    spawnSprintTrail(playerId, 6000);
                     break;
                 case "bloodthirst":
                     castBloodthirst({
@@ -4099,6 +4102,11 @@ export function Game({models, sounds, textures, matchId, character}) {
                             break;
                         case "berserk":
                             igniteHands(message.id, 1000);
+                            if (message.id === myPlayerId) {
+                                applySpeedEffect(myPlayerId, 6000, 1.5);
+                                applyFreedomEffect(myPlayerId, 6000);
+                                spawnSprintTrail(myPlayerId, 6000);
+                            }
                             break;
                         case "bloodthirst":
                             break;


### PR DESCRIPTION
## Summary
- enhance Berserk with sprint animation and slow/root immunity
- add Berserk buff on the server
- prevent slow/root while Berserk is active

## Testing
- `npm test` in `server`
- `npm test` in `client/next-js` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686798ad346c8329ac266a6d9b922d81