### PR TITLE
Show skill descriptions during loading

### DIFF
--- a/client/next-js/app/matches/[id]/page.tsx
+++ b/client/next-js/app/matches/[id]/page.tsx
@@ -31,6 +31,7 @@ import * as warlockSkills from "@/skills/warlock";
 import * as paladinSkills from "@/skills/paladin";
 import * as rogueSkills from "@/skills/rogue";
 import * as warriorSkills from "@/skills/warrior";
+import { SkillsList } from "@/components/skills-list";
 
 type Match = MatchDetail;
 
@@ -372,32 +373,10 @@ export default function MatchesPage() {
                       </ul>
                     </div>
                   )}
-                  <div className="mt-4 w-full">
-                    <h4 className="text-yellow-400 text-sm font-semibold mb-1">
-                      Skills
-                    </h4>
-                    <div className="grid grid-cols-2 gap-2">
-                      {classOptions[selectedClassPreview].skills.map((sk) => (
-                        <div key={sk.id} className="flex gap-2 items-start">
-                          <Image
-                            alt={sk.name}
-                            height={32}
-                            src={sk.icon}
-                            width={32}
-                          />
-                          <div className="text-xs">
-                            <div className="font-semibold flex items-center gap-1">
-                              {sk.name}
-                              <Kbd>{sk.key}</Kbd>
-                            </div>
-                            <div className="text-[10px] text-gray-300">
-                              {sk.description}
-                            </div>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
+                  <SkillsList
+                    className="mt-4 w-full"
+                    skills={classOptions[selectedClassPreview].skills}
+                  />
                 </ModalBody>
                 <ModalFooter className="flex gap-2">
                   <Button color="secondary" onPress={onClose}>

--- a/client/next-js/components/loading.tsx
+++ b/client/next-js/components/loading.tsx
@@ -1,10 +1,185 @@
 import Image from "next/image";
 import React from "react";
+import { SkillsList } from "@/components/skills-list";
+
+import { useInterface } from "@/context/inteface";
+import * as mageSkills from "@/skills/mage";
+import * as warlockSkills from "@/skills/warlock";
+import * as paladinSkills from "@/skills/paladin";
+import * as rogueSkills from "@/skills/rogue";
+import * as warriorSkills from "@/skills/warrior";
 
 interface LoadingProps {
   text: string;
 }
+
+const CLASS_SKILLS = {
+  warrior: [
+    {
+      ...warriorSkills.warbringer,
+      name: "Warbringer",
+      description: "Charge to an enemy.",
+    },
+    {
+      ...warriorSkills.savageBlow,
+      name: "Savage Blow",
+      description: "Powerful melee attack.",
+    },
+    {
+      ...warriorSkills.hamstring,
+      name: "Hamstring",
+      description: "Slows the enemy.",
+    },
+    {
+      ...warriorSkills.bladestorm,
+      name: "Bladestorm",
+      description: "Spin to hit all nearby foes.",
+    },
+    {
+      ...warriorSkills.berserk,
+      name: "Berserk",
+      description: "Increase attack power.",
+    },
+    {
+      ...warriorSkills.bloodthirst,
+      name: "Bloodthirst",
+      description: "Attack that heals you.",
+    },
+  ],
+  paladin: [
+    {
+      ...paladinSkills.lightstrike,
+      name: "Light Strike",
+      description: "Strike with holy power.",
+    },
+    { ...paladinSkills.stun, name: "Stun", description: "Stuns the enemy." },
+    {
+      ...paladinSkills.paladinHeal,
+      name: "Heal",
+      description: "Restore health to an ally.",
+    },
+    {
+      ...paladinSkills.lightwave,
+      name: "Lightwave",
+      description: "Wave of holy light.",
+    },
+    {
+      ...paladinSkills.handOfFreedom,
+      name: "Hand of Freedom",
+      description: "Removes movement effects.",
+    },
+    {
+      ...paladinSkills.divineSpeed,
+      name: "Divine Speed",
+      description: "Boosts movement speed.",
+    },
+  ],
+  rogue: [
+    {
+      ...rogueSkills.bloodStrike,
+      name: "Blood Strike",
+      description: "Strike the enemy quickly.",
+    },
+    {
+      ...rogueSkills.eviscerate,
+      name: "Eviscerate",
+      description: "Finishing move with high damage.",
+    },
+    {
+      ...rogueSkills.shadowLeap,
+      name: "Shadow Leap",
+      description: "Leap through shadows to target.",
+    },
+    {
+      ...rogueSkills.kidneyStrike,
+      name: "Kidney Strike",
+      description: "Stuns the enemy from behind.",
+    },
+    {
+      ...rogueSkills.sprint,
+      name: "Sprint",
+      description: "Increase movement speed.",
+    },
+    {
+      ...rogueSkills.adrenalineRush,
+      name: "Adrenaline Rush",
+      description: "Greatly boosts attack speed.",
+    },
+  ],
+  warlock: [
+    {
+      ...warlockSkills.darkball,
+      name: "Darkball",
+      description: "Shadow bolt dealing damage.",
+    },
+    {
+      ...warlockSkills.corruption,
+      name: "Corruption",
+      description: "Inflicts damage over time.",
+    },
+    {
+      ...warlockSkills.lifetap,
+      name: "Lifetap",
+      description: "Convert health into mana.",
+    },
+    {
+      ...warlockSkills.chaosbolt,
+      name: "Chaosbolt",
+      description: "Unleash chaotic energy.",
+    },
+    {
+      ...warlockSkills.fear,
+      name: "Fear",
+      description: "Terrifies the target.",
+    },
+    {
+      ...warlockSkills.lifedrain,
+      name: "Lifedrain",
+      description: "Drain health from target.",
+    },
+  ],
+  mage: [
+    {
+      ...mageSkills.fireball,
+      name: "Fireball",
+      description: "Hurls a fiery ball.",
+    },
+    {
+      ...mageSkills.iceball,
+      name: "Iceball",
+      description: "Launches a chilling bolt.",
+    },
+    {
+      ...mageSkills.frostnova,
+      name: "Frost Nova",
+      description: "Freezes enemies around you.",
+    },
+    {
+      ...mageSkills.blink,
+      name: "Blink",
+      description: "Teleport a short distance.",
+    },
+    {
+      ...mageSkills.fireblast,
+      name: "Fireblast",
+      description: "Instant burst of flame.",
+    },
+    {
+      ...mageSkills.pyroblast,
+      name: "Pyroblast",
+      description: "Massive fireball.",
+    },
+  ],
+} as const;
+
 export const Loading = ({ text }: LoadingProps) => {
+  const {
+    state: { character },
+  } = useInterface() as { state: { character: { name?: string } | null } };
+  const skills = character?.name
+    ? CLASS_SKILLS[character.name as keyof typeof CLASS_SKILLS]
+    : [];
+
   return (
     <div className="w-full h-full flex justify-center items-center">
       <Image
@@ -14,7 +189,16 @@ export const Loading = ({ text }: LoadingProps) => {
         src="/loading.webp"
         width={3840}
       />
-      <span className="absolute z-[3] text-xl font-semibold">{text}</span>
+      <span className="absolute z-[3] text-xl font-semibold text-white">
+        {text}
+      </span>
+      {skills && skills.length > 0 && (
+        <SkillsList
+          className="absolute bottom-4 left-1/2 -translate-x-1/2 z-[3] bg-black/70 p-4 rounded max-w-md text-white text-xs"
+          headingClassName="text-center text-sm font-bold mb-2"
+          skills={skills}
+        />
+      )}
     </div>
   );
 };

--- a/client/next-js/components/skills-list.tsx
+++ b/client/next-js/components/skills-list.tsx
@@ -1,0 +1,49 @@
+import Image from "next/image";
+import { Kbd } from "@heroui/kbd";
+import React from "react";
+
+interface Skill {
+  id: string | number;
+  icon: string;
+  key: string | number;
+  name: string;
+  description: string;
+}
+
+interface SkillsListProps {
+  skills: Skill[];
+  /** Additional classes for the container */
+  className?: string;
+  /** Classes for the title */
+  headingClassName?: string;
+  /** Heading text */
+  title?: string;
+}
+
+export const SkillsList = ({
+  skills,
+  className = "",
+  headingClassName = "text-yellow-400 text-sm font-semibold mb-1",
+  title = "Skills",
+}: SkillsListProps) => {
+  if (!skills || skills.length === 0) return null;
+  return (
+    <div className={className}>
+      <h4 className={headingClassName}>{title}</h4>
+      <div className="grid grid-cols-2 gap-2">
+        {skills.map((sk) => (
+          <div key={sk.id} className="flex gap-2 items-start">
+            <Image alt={sk.name} height={32} src={sk.icon} width={32} />
+            <div className="text-xs">
+              <div className="font-semibold flex items-center gap-1">
+                {sk.name}
+                <Kbd>{sk.key}</Kbd>
+              </div>
+              <div className="text-[10px] text-gray-300">{sk.description}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- create `SkillsList` component for rendering class skills
- reuse `SkillsList` in match lobby and loading screen

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*

------
https://chatgpt.com/codex/tasks/task_e_68690678159083298e27dbc9a51d0c40