### PR TITLE
Increase aim beam line width

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -993,6 +993,7 @@ export function Game({models, sounds, textures, matchId, character}) {
 
         const AIM_BEAM_OPACITY = 0.5;
         const AIM_BEAM_LENGTH = SPHERE_MAX_DISTANCE * 1.5;
+        const AIM_BEAM_LINEWIDTH = 4;
         let aimBeam = null;
 
         function createAimBeam() {
@@ -1001,6 +1002,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                 transparent: true,
                 opacity: AIM_BEAM_OPACITY,
                 depthWrite: false,
+                linewidth: AIM_BEAM_LINEWIDTH,
             });
             const geometry = new THREE.BufferGeometry();
             geometry.setFromPoints([new THREE.Vector3(), new THREE.Vector3()]);


### PR DESCRIPTION
## Summary
- make aiming beam easier to see by increasing its line width

## Testing
- `npm test` (fails: no test specified)
- `npm test` in client (fails: missing script)


------
https://chatgpt.com/codex/tasks/task_e_686a22f02eb483299ee730b9e032bec5