### PR TITLE
Add background music pause toggle

### DIFF
--- a/client/next-js/app/layout.tsx
+++ b/client/next-js/app/layout.tsx
@@ -5,8 +5,8 @@ import React from "react";
 import "@mysten/dapp-kit/dist/index.css";
 
 import { Providers } from "./providers";
-import { BackgroundMusic } from "@/components/background-music";
 
+import { BackgroundMusic } from "@/components/background-music";
 import { siteConfig } from "@/config/site";
 import { fontSans } from "@/config/fonts";
 
@@ -42,10 +42,11 @@ export default function RootLayout({
           fontSans.variable,
         )}
       >
-        <Providers themeProps={{ attribute: "class", defaultTheme: "dark" }}>
-          <BackgroundMusic />
-          <div className=" h-screen w-screen">{children}</div>
-        </Providers>
+        <BackgroundMusic>
+          <Providers themeProps={{ attribute: "class", defaultTheme: "dark" }}>
+            <div className=" h-screen w-screen">{children}</div>
+          </Providers>
+        </BackgroundMusic>
         <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.7/dist/TextPlugin.min.js" />
       </body>
     </html>

--- a/client/next-js/components/background-music.tsx
+++ b/client/next-js/components/background-music.tsx
@@ -1,21 +1,63 @@
-'use client'
+"use client";
 
-import { useEffect, useRef } from 'react';
-import { usePathname } from 'next/navigation';
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { usePathname } from "next/navigation";
 
-export function BackgroundMusic() {
+interface BackgroundMusicCtx {
+  playing: boolean;
+  toggle: () => void;
+}
+
+const BackgroundMusicContext = createContext<BackgroundMusicCtx | undefined>(
+  undefined,
+);
+
+export function useBackgroundMusic() {
+  const ctx = useContext(BackgroundMusicContext);
+
+  if (!ctx) {
+    throw new Error("useBackgroundMusic must be used within BackgroundMusic");
+  }
+
+  return ctx;
+}
+
+export function BackgroundMusic({ children }: { children?: React.ReactNode }) {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const pathname = usePathname();
+  const [playing, setPlaying] = useState(true);
+
+  const toggle = () => {
+    const audio = audioRef.current;
+
+    if (!audio) return;
+    if (audio.paused) {
+      audio.play().catch(() => {});
+      setPlaying(true);
+    } else {
+      audio.pause();
+      setPlaying(false);
+    }
+  };
 
   useEffect(() => {
     const audio = audioRef.current;
+
     if (!audio) return;
     audio.volume = 0.5;
     audio.loop = true;
-    if (/^\/matches\/[^/]+\/game/.test(pathname || '')) {
+    if (/^\/matches\/[^/]+\/game/.test(pathname || "")) {
       audio.pause();
+      setPlaying(false);
     } else {
       audio.play().catch(() => {});
+      setPlaying(true);
     }
   }, [pathname]);
 
@@ -25,7 +67,12 @@ export function BackgroundMusic() {
     };
   }, []);
 
-  return <audio ref={audioRef} src="/bg.mp3" autoPlay >
-    <track kind="captions" />
-  </audio>;
+  return (
+    <BackgroundMusicContext.Provider value={{ playing, toggle }}>
+      <audio ref={audioRef} autoPlay hidden src="/bg.mp3">
+        <track kind="captions" />
+      </audio>
+      {children}
+    </BackgroundMusicContext.Provider>
+  );
 }

--- a/client/next-js/components/icons.tsx
+++ b/client/next-js/components/icons.tsx
@@ -205,3 +205,38 @@ export const CoinIcon = (
     />
   </svg>
 );
+
+export const PlayIcon: React.FC<IconSvgProps> = ({
+  size = 24,
+  width,
+  height,
+  ...props
+}) => (
+  <svg
+    fill="currentColor"
+    height={size || height}
+    viewBox="0 0 24 24"
+    width={size || width}
+    {...props}
+  >
+    <polygon points="5,3 19,12 5,21" />
+  </svg>
+);
+
+export const PauseIcon: React.FC<IconSvgProps> = ({
+  size = 24,
+  width,
+  height,
+  ...props
+}) => (
+  <svg
+    fill="currentColor"
+    height={size || height}
+    viewBox="0 0 24 24"
+    width={size || width}
+    {...props}
+  >
+    <rect height="16" width="4" x="6" y="4" />
+    <rect height="16" width="4" x="14" y="4" />
+  </svg>
+);

--- a/client/next-js/components/navbar.tsx
+++ b/client/next-js/components/navbar.tsx
@@ -27,13 +27,22 @@ import {
 
 import { siteConfig } from "@/config/site";
 import { ThemeSwitch } from "@/components/theme-switch";
-import { GithubIcon, DiscordIcon, SearchIcon } from "@/components/icons";
+import {
+  GithubIcon,
+  DiscordIcon,
+  SearchIcon,
+  PlayIcon,
+  PauseIcon,
+} from "@/components/icons";
+import { useBackgroundMusic } from "@/components/background-music";
 
 let clickedOnBalance = 0;
 
 export const Navbar = () => {
   const account = useCurrentAccount();
   const { currentWallet, connectionStatus } = useCurrentWallet();
+
+  const { playing, toggle } = useBackgroundMusic();
 
   const router = useRouter();
 
@@ -119,6 +128,18 @@ export const Navbar = () => {
           <Link isExternal aria-label="Github" href={siteConfig.links.github}>
             <GithubIcon className="text-default-500" />
           </Link>
+          <button
+            aria-label={playing ? "Pause music" : "Play music"}
+            className="px-px transition-opacity hover:opacity-80 cursor-pointer"
+            type="button"
+            onClick={toggle}
+          >
+            {playing ? (
+              <PauseIcon className="text-default-500" />
+            ) : (
+              <PlayIcon className="text-default-500" />
+            )}
+          </button>
           {/*<ThemeSwitch />*/}
         </NavbarItem>
         {/*<NavbarItem className="hidden lg:flex">{searchInput}</NavbarItem>*/}


### PR DESCRIPTION
## Summary
- wrap Providers with `BackgroundMusic` to supply music context
- add play/pause icons
- add pause control button in the Navbar
- manage playing state in `BackgroundMusic` and expose toggle hook

## Testing
- `npm run lint`
- `npm run build` *(fails: Property 'darkball' does not exist on type)*

------
https://chatgpt.com/codex/tasks/task_e_686a27431f288329bac71a4b042cdf78