### PR TITLE
Update loading screen with instructions

### DIFF
--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -11,7 +11,6 @@ import { ExperienceBar } from "../parts/ExperienceBar.jsx";
 import { LevelUp } from "../parts/LevelUp.jsx";
 import { KillNotification } from "../parts/KillNotification.jsx";
 import { StatsModal } from "../parts/StatsModal.jsx";
-import { HowToPlayModal } from "../parts/HowToPlayModal.jsx";
 
 import { useInterface } from "@/context/inteface";
 import { CLASS_ICONS } from "@/consts/classes";
@@ -263,7 +262,6 @@ export const Interface = () => {
 
       <Scoreboard />
       <StatsModal />
-      <HowToPlayModal />
       <GameMenu />
       <Buffs />
       <SkillBar

--- a/client/next-js/components/loading.tsx
+++ b/client/next-js/components/loading.tsx
@@ -1,185 +1,14 @@
 import Image from "next/image";
 import React from "react";
+import { Progress } from "@heroui/react";
 
-import { SkillsList } from "@/components/skills-list";
-import { useInterface } from "@/context/inteface";
-import * as mageSkills from "@/skills/mage";
-import * as warlockSkills from "@/skills/warlock";
-import * as paladinSkills from "@/skills/paladin";
-import * as rogueSkills from "@/skills/rogue";
-import * as warriorSkills from "@/skills/warrior";
+import { assetUrl } from "@/utilities/assets";
 
 interface LoadingProps {
   text: string;
 }
 
-const CLASS_SKILLS = {
-  warrior: [
-    {
-      ...warriorSkills.warbringer,
-      name: "Warbringer",
-      description: "Charge to an enemy.",
-    },
-    {
-      ...warriorSkills.savageBlow,
-      name: "Savage Blow",
-      description: "Powerful melee attack.",
-    },
-    {
-      ...warriorSkills.hamstring,
-      name: "Hamstring",
-      description: "Slows the enemy.",
-    },
-    {
-      ...warriorSkills.bladestorm,
-      name: "Bladestorm",
-      description: "Spin to hit all nearby foes.",
-    },
-    {
-      ...warriorSkills.berserk,
-      name: "Berserk",
-      description: "Increase attack power.",
-    },
-    {
-      ...warriorSkills.bloodthirst,
-      name: "Bloodthirst",
-      description: "Attack that heals you.",
-    },
-  ],
-  paladin: [
-    {
-      ...paladinSkills.lightstrike,
-      name: "Light Strike",
-      description: "Strike with holy power.",
-    },
-    { ...paladinSkills.stun, name: "Stun", description: "Stuns the enemy." },
-    {
-      ...paladinSkills.paladinHeal,
-      name: "Heal",
-      description: "Restore health to an ally.",
-    },
-    {
-      ...paladinSkills.lightwave,
-      name: "Lightwave",
-      description: "Wave of holy light.",
-    },
-    {
-      ...paladinSkills.handOfFreedom,
-      name: "Hand of Freedom",
-      description: "Removes movement effects.",
-    },
-    {
-      ...paladinSkills.divineSpeed,
-      name: "Divine Speed",
-      description: "Boosts movement speed.",
-    },
-  ],
-  rogue: [
-    {
-      ...rogueSkills.bloodStrike,
-      name: "Blood Strike",
-      description: "Strike the enemy quickly.",
-    },
-    {
-      ...rogueSkills.eviscerate,
-      name: "Eviscerate",
-      description: "Finishing move with high damage.",
-    },
-    {
-      ...rogueSkills.shadowLeap,
-      name: "Shadow Leap",
-      description: "Leap through shadows to target.",
-    },
-    {
-      ...rogueSkills.kidneyStrike,
-      name: "Kidney Strike",
-      description: "Stuns the enemy from behind.",
-    },
-    {
-      ...rogueSkills.sprint,
-      name: "Sprint",
-      description: "Increase movement speed.",
-    },
-    {
-      ...rogueSkills.adrenalineRush,
-      name: "Adrenaline Rush",
-      description: "Greatly boosts attack speed.",
-    },
-  ],
-  warlock: [
-    {
-      ...warlockSkills.darkball,
-      name: "Darkball",
-      description: "Shadow bolt dealing damage.",
-    },
-    {
-      ...warlockSkills.corruption,
-      name: "Corruption",
-      description: "Inflicts damage over time.",
-    },
-    {
-      ...warlockSkills.lifetap,
-      name: "Lifetap",
-      description: "Convert health into mana.",
-    },
-    {
-      ...warlockSkills.chaosbolt,
-      name: "Chaosbolt",
-      description: "Unleash chaotic energy.",
-    },
-    {
-      ...warlockSkills.fear,
-      name: "Fear",
-      description: "Terrifies the target.",
-    },
-    {
-      ...warlockSkills.lifedrain,
-      name: "Lifedrain",
-      description: "Drain health from target.",
-    },
-  ],
-  mage: [
-    {
-      ...mageSkills.fireball,
-      name: "Fireball",
-      description: "Hurls a fiery ball.",
-    },
-    {
-      ...mageSkills.iceball,
-      name: "Iceball",
-      description: "Launches a chilling bolt.",
-    },
-    {
-      ...mageSkills.frostnova,
-      name: "Frost Nova",
-      description: "Freezes enemies around you.",
-    },
-    {
-      ...mageSkills.blink,
-      name: "Blink",
-      description: "Teleport a short distance.",
-    },
-    {
-      ...mageSkills.fireblast,
-      name: "Fireblast",
-      description: "Instant burst of flame.",
-    },
-    {
-      ...mageSkills.pyroblast,
-      name: "Pyroblast",
-      description: "Massive fireball.",
-    },
-  ],
-} as const;
-
 export const Loading = ({ text }: LoadingProps) => {
-  const {
-    state: { character },
-  } = useInterface() as { state: { character: { name?: string } | null } };
-  const skills = character?.name
-    ? CLASS_SKILLS[character.name as keyof typeof CLASS_SKILLS]
-    : [];
-
   const imageSrc = React.useMemo(() => {
     const images = [
       "/loading-1.webp",
@@ -190,6 +19,16 @@ export const Loading = ({ text }: LoadingProps) => {
     ];
 
     return images[Math.floor(Math.random() * images.length)];
+  }, []);
+
+  const [progress, setProgress] = React.useState(0);
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setProgress((p) => (p >= 100 ? 0 : p + 1));
+    }, 50);
+
+    return () => clearInterval(interval);
   }, []);
 
   return (
@@ -204,13 +43,14 @@ export const Loading = ({ text }: LoadingProps) => {
       <span className="absolute z-[3] text-xl font-semibold text-white">
         {text}
       </span>
-      {skills && skills.length > 0 && (
-        <SkillsList
-          className="absolute bottom-4 left-1/2 -translate-x-1/2 z-[3] bg-black/70 p-4 rounded max-w-md text-white text-xs"
-          headingClassName="text-center text-sm font-bold mb-2"
-          skills={skills}
+      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-[3] flex flex-col items-center gap-2">
+        <img
+          alt="How to play"
+          className="w-96 h-auto"
+          src={assetUrl("/images/how-to-play.webp")}
         />
-      )}
+        <Progress aria-label="Loading" className="w-full" value={progress} />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- replace skills list with how-to-play image on loading screen
- animate loading progress
- remove HowToPlay modal from game interface

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a29b7946c8329be27afa5cb1d1b92