### PR TITLE
Add click sound wrapper for UI buttons

### DIFF
--- a/client/next-js/app/dao/page.tsx
+++ b/client/next-js/app/dao/page.tsx
@@ -8,10 +8,10 @@ import {
   TableBody,
   TableRow,
   TableCell,
-  Button,
   addToast,
 } from "@heroui/react";
 
+import { ButtonWithSound as Button } from "@/components/button-with-sound";
 import { Navbar } from "@/components/navbar";
 import { title } from "@/components/primitives";
 import { useDao } from "@/hooks/useDao";

--- a/client/next-js/app/matches/[id]/page.tsx
+++ b/client/next-js/app/matches/[id]/page.tsx
@@ -2,7 +2,6 @@
 import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 import {
-  Button,
   Table,
   TableHeader,
   TableColumn,
@@ -18,6 +17,7 @@ import {
   ModalFooter,
 } from "@heroui/modal";
 import { Kbd } from "@heroui/kbd";
+import { ButtonWithSound as Button } from "@/components/button-with-sound";
 import { useParams, useRouter } from "next/navigation";
 
 import { assetUrl } from "@/utilities/assets";

--- a/client/next-js/app/matches/[id]/summary/page.tsx
+++ b/client/next-js/app/matches/[id]/summary/page.tsx
@@ -8,10 +8,10 @@ import {
   TableBody,
   TableRow,
   TableCell,
-  Button,
 } from "@heroui/react";
 import { useParams, useRouter } from "next/navigation";
 
+import { ButtonWithSound as Button } from "@/components/button-with-sound";
 import { useWS } from "@/hooks/useWS";
 import { Navbar } from "@/components/navbar";
 

--- a/client/next-js/app/matches/page.tsx
+++ b/client/next-js/app/matches/page.tsx
@@ -7,7 +7,6 @@ import {
   TableBody,
   TableRow,
   TableCell,
-  Button,
   useDisclosure,
 } from "@heroui/react";
 import {
@@ -20,6 +19,7 @@ import {
 import { Input } from "@heroui/input";
 import { useRouter } from "next/navigation";
 
+import { ButtonWithSound as Button } from "@/components/button-with-sound";
 import { useWS } from "@/hooks/useWS";
 import { Navbar } from "@/components/navbar";
 

--- a/client/next-js/components/button-with-sound.tsx
+++ b/client/next-js/components/button-with-sound.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import React, { useRef } from "react";
+import { Button, type ButtonProps } from "@heroui/react";
+
+export function ButtonWithSound({ onPress, ...props }: ButtonProps) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  const handlePress: typeof onPress = (event) => {
+    if (audioRef.current) {
+      try {
+        audioRef.current.currentTime = 0;
+        audioRef.current.play().catch(() => {});
+      } catch {
+        // ignore play errors
+      }
+    }
+    onPress?.(event);
+  };
+
+  return (
+    <>
+      <audio ref={audioRef} hidden src="/click.mp3">
+        <track kind="captions" />
+      </audio>
+      <Button {...props} onPress={handlePress} />
+    </>
+  );
+}

--- a/client/next-js/components/connection-button.tsx
+++ b/client/next-js/components/connection-button.tsx
@@ -1,7 +1,8 @@
 import { ConnectModal, useCurrentAccount } from "@mysten/dapp-kit";
 import React, { useState } from "react";
-import { Button } from "@heroui/react";
 import { useRouter } from "next/navigation";
+
+import { ButtonWithSound as Button } from "@/components/button-with-sound";
 
 interface ConnectionButton {
   className?: string;

--- a/client/next-js/components/general.tsx
+++ b/client/next-js/components/general.tsx
@@ -1,9 +1,9 @@
 "use client";
 import React, { useRef, useEffect, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Button } from "@heroui/react";
 import { useRouter } from "next/navigation";
 
+import { ButtonWithSound as Button } from "@/components/button-with-sound";
 import { title as getTitle, subtitle } from "@/components/primitives";
 
 // Sui JS SDK

--- a/client/next-js/components/navbar.tsx
+++ b/client/next-js/components/navbar.tsx
@@ -9,7 +9,6 @@ import {
   NavbarItem,
   NavbarMenuItem,
 } from "@heroui/navbar";
-import { Button } from "@heroui/button";
 import { Kbd } from "@heroui/kbd";
 import { Link } from "@heroui/link";
 import { Input } from "@heroui/input";
@@ -25,6 +24,7 @@ import {
   useSuiClientQuery,
 } from "@mysten/dapp-kit";
 
+import { ButtonWithSound as Button } from "@/components/button-with-sound";
 import { siteConfig } from "@/config/site";
 import { ThemeSwitch } from "@/components/theme-switch";
 import {

--- a/client/next-js/components/parts/Menu.jsx
+++ b/client/next-js/components/parts/Menu.jsx
@@ -1,6 +1,6 @@
 import { useInterface } from "../../context/inteface";
 import { useRouter } from "next/navigation";
-import { Button } from "@heroui/react";
+import { ButtonWithSound as Button } from "../button-with-sound";
 import "./Menu.css";
 
 export const GameMenu = () => {

--- a/client/next-js/components/profile-form.tsx
+++ b/client/next-js/components/profile-form.tsx
@@ -2,9 +2,9 @@
 
 import { useState, useEffect } from "react";
 import { Input } from "@heroui/input";
-import { Button } from "@heroui/react";
 import { useRouter } from "next/navigation";
 
+import { ButtonWithSound as Button } from "@/components/button-with-sound";
 import { useWS } from "@/hooks/useWS";
 
 export interface ProfileFormProps {


### PR DESCRIPTION
## Summary
- add `ButtonWithSound` component that plays `/click.mp3`
- wrap existing buttons in new component across the app

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a3cbfacd0832995624e0f7cd31d45