### PR TITLE
Fix fireball scaling

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -2104,12 +2104,12 @@ export function Game({models, sounds, textures, matchId, character}) {
         }
 
 
-        function createSphereTail(color) {
+        function createSphereTail(color, spellScale = 1) {
             const tailSprites = [];
             const tailPositions = [];
             for (let i = 0; i < FIREBALL_TAIL_SEGMENTS; i++) {
-                const scale = 0.15 * (1 - i / FIREBALL_TAIL_SEGMENTS);
-                const sprite = makeGlowSprite(color, scale);
+                const baseScale = 0.15 * (1 - i / FIREBALL_TAIL_SEGMENTS);
+                const sprite = makeGlowSprite(color, baseScale * spellScale);
                 sprite.visible = false;
                 scene.add(sprite);
                 tailSprites.push(sprite);
@@ -3810,7 +3810,8 @@ export function Game({models, sounds, textures, matchId, character}) {
             let tailPositions = null;
             const tailColor = SPELL_TAIL_COLORS[data.type];
             if (tailColor !== undefined) {
-                ({ tailSprites, tailPositions } = createSphereTail(tailColor));
+                const spellScale = SPELL_SCALES[data.type] || 1;
+                ({ tailSprites, tailPositions } = createSphereTail(tailColor, spellScale));
             }
 
             scene.add(mesh);


### PR DESCRIPTION
## Summary
- scale fireball tail segments relative to spell scale so the whole fireball grows uniformly

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686a4c1ce758832995ccfb151a99ce72