### PR TITLE
Fix fireball and frostball visuals

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -560,8 +560,8 @@ export function Game({models, sounds, textures, matchId, character}) {
         const sparkTexture = textures.sparkle;
         const fireballMaterial = new THREE.ShaderMaterial({
             transparent: false,
-            depthWrite: false,
-            blending: THREE.AdditiveBlending,
+            depthWrite: true,
+            blending: THREE.NormalBlending,
             uniforms: {
                 time: {value: 0},
                 perlinnoise: {value: perlinTexture},
@@ -679,7 +679,7 @@ export function Game({models, sounds, textures, matchId, character}) {
         fireballMesh.scale.set(
             SPELL_SCALES.fireball,
             SPELL_SCALES.fireball,
-            SPELL_SCALES.fireball * 1.3,
+            SPELL_SCALES.fireball,
         );
 
         const pyroblastMesh = new THREE.Mesh(
@@ -782,15 +782,15 @@ export function Game({models, sounds, textures, matchId, character}) {
     }
   `,
             transparent: false,
-            blending: THREE.AdditiveBlending,
-            depthWrite: false,
+            blending: THREE.NormalBlending,
+            depthWrite: true,
         });
 
         const iceballMesh = new THREE.Mesh(iceballGeometry, iceballMaterial.clone());
         iceballMesh.scale.set(
             SPELL_SCALES.iceball,
             SPELL_SCALES.iceball,
-            SPELL_SCALES.iceball * 1.3,
+            SPELL_SCALES.iceball,
         );
 
 


### PR DESCRIPTION
## Summary
- adjust fireball and iceball meshes to keep them spherical
- use normal blending with depth writing to give projectiles a solid look

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686a536baac48329b99ca1ebb6529cb1