### PR TITLE
Fix default skills for class selection

### DIFF
--- a/server/server.cjs
+++ b/server/server.cjs
@@ -826,6 +826,19 @@ ws.on('connection', (socket) => {
                     const myPlayer = players.get(id);
                     myPlayer.classType = message.classType;
                     myPlayer.character = message.character;
+                    const stats = CLASS_STATS[message.classType] || { hp: MAX_HP, armor: 0, mana: MAX_MANA };
+                    myPlayer.hp = stats.hp;
+                    myPlayer.maxHp = stats.hp;
+                    myPlayer.armor = stats.armor;
+                    myPlayer.maxArmor = stats.armor;
+                    myPlayer.mana = stats.mana || MAX_MANA;
+                    myPlayer.maxMana = stats.mana || MAX_MANA;
+                    if (CLASS_E_SKILL[message.classType]) {
+                        myPlayer.learnedSkills = {
+                            ...myPlayer.learnedSkills,
+                            [CLASS_E_SKILL[message.classType]]: true,
+                        };
+                    }
                     socket.send(JSON.stringify({
                         type: 'CHARACTER_READY'
                     }))


### PR DESCRIPTION
## Summary
- update server to assign class stats and default skill on `SET_CHARACTER`

## Testing
- `npm test` in `server/` *(fails: Error: no test specified)*
- `npm test` in `client/next-js/` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_686a54845ae88329ba323324b32bcfb9