### PR TITLE
Fix target selection with improved raycast

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -1585,10 +1585,9 @@ export function Game({models, sounds, textures, matchId, character}) {
             let minDist = Infinity;
             players.forEach((p, id) => {
                 if (id === myPlayerId) return;
-                const box = new THREE.Box3().setFromObject(p.model);
-                const hit = raycaster.ray.intersectBox(box, new THREE.Vector3());
-                if (hit) {
-                    const dist = origin.distanceTo(hit);
+                const intersects = raycaster.intersectObject(p.model, true);
+                if (intersects.length > 0) {
+                    const dist = intersects[0].distance;
                     if (dist < minDist && hasLineOfSight(id)) {
                         minDist = dist;
                         closest = id;


### PR DESCRIPTION
## Summary
- improve raycasting logic for selecting targets

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686a66647fc88329ad7e7f7fa7e6cdb9