### PR TITLE
Fix camera drag rotation condition

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -3235,7 +3235,9 @@ export function Game({models, sounds, textures, matchId, character}) {
                 model.position.y -= 0.7;
                 // Rotate the model to match the camera direction
                 const locked = document.pointerLockElement === containerRef.current;
-                if (locked || !isCameraDragging) {
+                // Rotate the character model with the camera only when the
+                // pointer is locked and the player is not dragging the camera.
+                if (locked && !isCameraDragging) {
                     model.rotation.y = yaw + Math.PI;
                 }
                 // Get the camera's forward direction


### PR DESCRIPTION
## Summary
- handle camera drag properly by only rotating the player model when the mouse is locked and the camera isn't being dragged

## Testing
- `npm test` in `server` *(fails: no test specified)*
- `npm test` in `client/next-js` *(fails: missing script)*
- `npm run lint` in `client/next-js` *(fails: missing eslint-plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_686b9fc6ecc48329bddd4fe3ddd5b686