### PR TITLE
Add highlight marker to game

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -282,6 +282,8 @@ export function Game({models, sounds, textures, matchId, character}) {
         const MELEE_INDICATOR_OPACITY = 0.2; // transparency for the auto attack indicator
         const TARGET_INDICATOR_OPACITY = 0.4; // transparency for target highlight
         let targetIndicator = null;
+        let highlightIndicator = null;
+        let highlightedPlayerId = null;
 
         const createTargetIndicator = () => {
             const geometry = new THREE.RingGeometry(0.55, 0.7, 32);
@@ -308,6 +310,24 @@ export function Game({models, sounds, textures, matchId, character}) {
                 const player = players.get(targetedPlayerId).model;
                 targetIndicator = createTargetIndicator();
                 player.add(targetIndicator);
+            }
+        };
+
+        const createHighlightIndicator = () => {
+            const sprite = makeGlowSprite(0xff0000, 0.6);
+            sprite.position.y = 2.3;
+            return sprite;
+        };
+
+        const updateHighlightIndicator = () => {
+            if (highlightIndicator) {
+                highlightIndicator.parent?.remove(highlightIndicator);
+                highlightIndicator = null;
+            }
+            if (highlightedPlayerId && players.has(highlightedPlayerId)) {
+                const player = players.get(highlightedPlayerId).model;
+                highlightIndicator = createHighlightIndicator();
+                player.add(highlightIndicator);
             }
         };
 
@@ -1601,13 +1621,13 @@ export function Game({models, sounds, textures, matchId, character}) {
             }
 
             if (id && players.has(id) && hasLineOfSight(id)) {
-                if (targetedPlayerId !== id) {
-                    targetedPlayerId = id;
-                    dispatchTargetUpdate();
+                if (highlightedPlayerId !== id) {
+                    highlightedPlayerId = id;
+                    updateHighlightIndicator();
                 }
-            } else if (targetedPlayerId !== null) {
-                targetedPlayerId = null;
-                dispatchTargetUpdate();
+            } else if (highlightedPlayerId !== null) {
+                highlightedPlayerId = null;
+                updateHighlightIndicator();
             }
         }
 
@@ -3862,6 +3882,10 @@ export function Game({models, sounds, textures, matchId, character}) {
                 if (id === targetedPlayerId) {
                     targetedPlayerId = null;
                     dispatchTargetUpdate();
+                }
+                if (id === highlightedPlayerId) {
+                    highlightedPlayerId = null;
+                    updateHighlightIndicator();
                 }
             }
         }


### PR DESCRIPTION
## Summary
- highlight units with a red sprite when they are under the crosshair
- keep target ring only after clicking on a unit

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ba396c3148329909c4916f1ebb348