### PR TITLE
Delete empty matches when no players remain

### DIFF
--- a/server/server.cjs
+++ b/server/server.cjs
@@ -920,7 +920,7 @@ ws.on('connection', (socket) => {
                     matchToLeave.playersReady--;
                     playerMatchMap.delete(id);
 
-                    if (matchToLeave.players.size === 0 && matchToLeave.resorve.length === 0) {
+                    if (matchToLeave.players.size === 0) {
                         if (matchToLeave.finished && matchToLeave.summary) {
                             finishedMatches.set(matchToLeave.id, matchToLeave.summary);
                         }
@@ -1325,7 +1325,7 @@ ws.on('connection', (socket) => {
                 match.playersReady--;
                 match.isFull = false;
 
-                if (match.players.size === 0 && match.resorve.length === 0) {
+                if (match.players.size === 0) {
                     if (match.finished && match.summary) {
                         finishedMatches.set(match.id, match.summary);
                     }


### PR DESCRIPTION
## Summary
- clean up finished matches when all players leave

## Testing
- `npm test` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_686bb2a1de688329a99f9da688a352b5