### PR TITLE
Add hit position to projectile impact events

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -3005,13 +3005,17 @@ export function Game({models, sounds, textures, matchId, character}) {
             lightWaveRings.push({ mesh, start: performance.now(), duration });
         }
 
-        function spawnProjectileExplosion(playerId, color, duration = EXPLOSION_DURATION) {
-            const player = players.get(playerId)?.model;
-            if (!player) return;
-
-            const position = new THREE.Vector3();
-            player.getWorldPosition(position);
-            position.y += 1;
+        function spawnProjectileExplosion(playerId, color, impactPosition, duration = EXPLOSION_DURATION) {
+            let position;
+            if (impactPosition && typeof impactPosition.x === 'number') {
+                position = new THREE.Vector3(impactPosition.x, impactPosition.y, impactPosition.z);
+            } else {
+                const player = players.get(playerId)?.model;
+                if (!player) return;
+                position = new THREE.Vector3();
+                player.getWorldPosition(position);
+                position.y += 1;
+            }
 
             const geometry = new THREE.SphereGeometry(0.2, 16, 16);
             const material = new THREE.MeshBasicMaterial({
@@ -3877,7 +3881,19 @@ export function Game({models, sounds, textures, matchId, character}) {
                             freezeHands(message.id, 1000);
                             castSphereOtherUser(message.payload);
                             break;
+                        case "fireball-hit":
+                            spawnProjectileExplosion(
+                                message.payload.targetId,
+                                0xff6600,
+                                message.payload.position
+                            );
+                            break;
                         case "iceball-hit":
+                            spawnProjectileExplosion(
+                                message.payload.targetId,
+                                0x66ccff,
+                                message.payload.position
+                            );
                             if (message.payload.targetId === myPlayerId) {
                                 applySlowEffect(myPlayerId, 3000);
                             }
@@ -4150,10 +4166,6 @@ export function Game({models, sounds, textures, matchId, character}) {
                             sounds.damage.volume = 0.5;
                             sounds.damage.currentTime = 0;
                             sounds.damage.play();
-                        }
-                        if (message.spellType === 'fireball' || message.spellType === 'iceball') {
-                            const color = message.spellType === 'fireball' ? 0xff6600 : 0x66ccff;
-                            spawnProjectileExplosion(message.targetId, color);
                         }
                     }
                     break;

--- a/server/server.cjs
+++ b/server/server.cjs
@@ -613,10 +613,18 @@ ws.on('connection', (socket) => {
                     const r = PROJECTILE_RADIUS + 0.6;
                     if (d2 < r * r) {
                         applyDamage(match, pid, p.ownerId, p.damage, p.type);
-                        if (p.type === 'iceball') {
+                        if (p.type === 'iceball' || p.type === 'fireball') {
                             broadcastToMatch(match.id, {
                                 type: 'CAST_SPELL',
-                                payload: { type: 'iceball-hit', targetId: pid },
+                                payload: {
+                                    type: `${p.type}-hit`,
+                                    targetId: pid,
+                                    position: {
+                                        x: p.position.x,
+                                        y: p.position.y,
+                                        z: p.position.z,
+                                    },
+                                },
                                 id: p.ownerId,
                             });
                         }


### PR DESCRIPTION
## Summary
- include projectile impact position in server hit events
- spawn projectile explosions at the reported position on the client
- remove duplicate explosion from generic damage handler

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686bd162a06083299aada561d11bc2d6