### PR TITLE
Add projectile range indicator

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -280,7 +280,9 @@ export function Game({models, sounds, textures, matchId, character}) {
         let playerMixers = [];
 
         let meleeRangeIndicator = null;
+        let projectileRangeIndicator = null;
         const MELEE_INDICATOR_OPACITY = 0.2; // transparency for the auto attack indicator
+        const PROJECTILE_INDICATOR_OPACITY = 0.2; // transparency for the projectile range indicator
         const TARGET_INDICATOR_OPACITY = 0.4; // transparency for target highlight
         let targetIndicator = null;
         let highlightIndicator = null;
@@ -353,6 +355,25 @@ export function Game({models, sounds, textures, matchId, character}) {
             return mesh;
         };
 
+        const createProjectileIndicator = () => {
+            const geometry = new THREE.CircleGeometry(
+                SPHERE_MAX_DISTANCE,
+                64,
+            );
+            const material = new THREE.MeshBasicMaterial({
+                color: 0xffff00,
+                transparent: true,
+                opacity: PROJECTILE_INDICATOR_OPACITY,
+                side: THREE.DoubleSide,
+                depthWrite: false,
+                blending: THREE.AdditiveBlending,
+            });
+            const mesh = new THREE.Mesh(geometry, material);
+            mesh.rotation.x = Math.PI / 2;
+            mesh.position.y = 0.05;
+            return mesh;
+        };
+
         let movementSpeedModifier = 1; // Normal speed
 
         const damageBar = document.getElementById("damage");
@@ -375,6 +396,9 @@ export function Game({models, sounds, textures, matchId, character}) {
                 if (meleeRangeIndicator) {
                     meleeRangeIndicator.scale.setScalar(1 / currentScale);
                 }
+                if (projectileRangeIndicator) {
+                    projectileRangeIndicator.scale.setScalar(1 / currentScale);
+                }
             }
         };
 
@@ -394,8 +418,9 @@ export function Game({models, sounds, textures, matchId, character}) {
             scene.add(newModel);
             playerData.model = newModel;
             const cls = playerData.classType;
-            const allowed = ['paladin', 'warrior', 'rogue'];
-            if (allowed.includes(cls)) {
+            const meleeAllowed = ['paladin', 'warrior', 'rogue'];
+            const projectileAllowed = ['mage', 'warlock'];
+            if (meleeAllowed.includes(cls)) {
                 if (!meleeRangeIndicator) {
                     meleeRangeIndicator = createMeleeIndicator();
                 }
@@ -404,6 +429,16 @@ export function Game({models, sounds, textures, matchId, character}) {
             } else if (meleeRangeIndicator) {
                 meleeRangeIndicator.parent?.remove(meleeRangeIndicator);
                 meleeRangeIndicator = null;
+            }
+            if (projectileAllowed.includes(cls)) {
+                if (!projectileRangeIndicator) {
+                    projectileRangeIndicator = createProjectileIndicator();
+                }
+                newModel.add(projectileRangeIndicator);
+                projectileRangeIndicator.scale.setScalar(1 / currentScale);
+            } else if (projectileRangeIndicator) {
+                projectileRangeIndicator.parent?.remove(projectileRangeIndicator);
+                projectileRangeIndicator = null;
             }
         };
 
@@ -2441,7 +2476,8 @@ export function Game({models, sounds, textures, matchId, character}) {
                             mat.transparent = true;
                             mat.opacity = 0;
                             const targetOpacity =
-                                meleeRangeIndicator && obj === meleeRangeIndicator
+                                (meleeRangeIndicator && obj === meleeRangeIndicator) ||
+                                (projectileRangeIndicator && obj === projectileRangeIndicator)
                                     ? MELEE_INDICATOR_OPACITY
                                     : 1;
                             gsap.to(mat, {
@@ -3574,6 +3610,14 @@ export function Game({models, sounds, textures, matchId, character}) {
                     meleeRangeIndicator.scale.setScalar(1 / currentScale);
                     player.add(meleeRangeIndicator);
                 }
+                if (
+                    id === myPlayerId &&
+                    ['mage', 'warlock'].includes(classType)
+                ) {
+                    projectileRangeIndicator = createProjectileIndicator();
+                    projectileRangeIndicator.scale.setScalar(1 / currentScale);
+                    player.add(projectileRangeIndicator);
+                }
                 const stats = CLASS_STATS[classType] || { hp: MAX_HP, armor: 0, mana: MAX_MANA };
                 players.set(id, {
                     model: player,
@@ -3799,6 +3843,10 @@ export function Game({models, sounds, textures, matchId, character}) {
                 if (id === myPlayerId && meleeRangeIndicator) {
                     meleeRangeIndicator.parent?.remove(meleeRangeIndicator);
                     meleeRangeIndicator = null;
+                }
+                if (id === myPlayerId && projectileRangeIndicator) {
+                    projectileRangeIndicator.parent?.remove(projectileRangeIndicator);
+                    projectileRangeIndicator = null;
                 }
                 if (id === targetedPlayerId) {
                     targetedPlayerId = null;


### PR DESCRIPTION
## Summary
- show projectile range using a circular indicator similar to melee range
- keep indicator scaled with model and hide on player removal

## Testing
- `npm run lint` *(fails: eslint plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_686e4932368483299b43153fa215c5ff