### PR TITLE
Use projectile sprite for pyroblast

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -673,13 +673,8 @@ export function Game({models, sounds, textures, matchId, character}) {
             SPELL_SCALES.fireball,
         );
 
-        const pyroblastMesh = new THREE.Mesh(
-            fireballGeometry,
-            fireballMaterial.clone()
-        );
-        pyroblastMesh.scale.set(
-            SPELL_SCALES.pyroblast,
-            SPELL_SCALES.pyroblast,
+        const pyroblastMesh = makeProjectileSprite(
+            0xffaa33,
             SPELL_SCALES.pyroblast,
         );
 


### PR DESCRIPTION
## Summary
- update pyroblast to use the projectile glow sprite instead of sharing the fireball material

## Testing
- `npm run lint` *(fails: ESLint couldn't find plugin "eslint-plugin-react")*

------
https://chatgpt.com/codex/tasks/task_e_686e6d714ed48329a34d50321b216c4e