### PR TITLE
Add spinner animation to loading screen

### DIFF
--- a/client/next-js/components/loading.tsx
+++ b/client/next-js/components/loading.tsx
@@ -1,59 +1,67 @@
 import Image from "next/image";
 import React from "react";
-import {Progress} from "@heroui/react";
+import { Progress } from "@heroui/react";
 
-import {assetUrl} from "@/utilities/assets";
+import { assetUrl } from "@/utilities/assets";
 
 interface LoadingProps {
-    text: string;
-    hideProgress?: boolean;
+  text: string;
+  hideProgress?: boolean;
 }
 
 const getRandomImage = () => {
-    const images = [
-        "/loading-1.jpg",
-        "/loading-2.jpg",
-        "/loading-3.jpg",
-        "/loading-4.jpg",
-        "/loading-5.jpg",
-    ];
+  const images = [
+    "/loading-1.jpg",
+    "/loading-2.jpg",
+    "/loading-3.jpg",
+    "/loading-4.jpg",
+    "/loading-5.jpg",
+  ];
 
-    return images[Math.floor(Math.random() * images.length)];
-}
+  return images[Math.floor(Math.random() * images.length)];
+};
 
 const randomImage = getRandomImage();
 
-export const Loading = ({text, hideProgress = false}: LoadingProps) => {
-    const [progress, setProgress] = React.useState(0);
+export const Loading = ({ text, hideProgress = false }: LoadingProps) => {
+  const [progress, setProgress] = React.useState(0);
 
-    React.useEffect(() => {
-        const interval = setInterval(() => {
-            setProgress((p) => (p >= 100 ? 0 : p + 5));
-        }, 50);
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setProgress((p) => (p >= 100 ? 0 : p + 5));
+    }, 50);
 
-        return () => clearInterval(interval);
-    }, []);
+    return () => clearInterval(interval);
+  }, []);
 
-    return (
-        <div className="w-full h-full flex justify-center items-center">
-            <Image
-                alt="Turtle Art"
-                className="absolute top-0 left-0 w-full h-full object-cover z-[4]"
-                height={1961}
-                src={randomImage}
-                width={3840}
-            />
-            <span className="absolute z-[5] text-xxl font-semibold text-white">
-        {text}
-      </span>
-            <div className="absolute bottom-12 left-1/2 -translate-x-1/2 z-[5] flex flex-col items-center gap-2">
-                <img
-                    alt="How to play"
-                    className="w-96 h-auto"
-                    src={assetUrl("/images/how-to-play.webp")}
-                />
-                {!hideProgress && <Progress disableAnimation aria-label="Loading" className="w-full" value={progress}/>}
-            </div>
-        </div>
-    );
+  return (
+    <div className="w-full h-full flex justify-center items-center">
+      <Image
+        alt="Turtle Art"
+        className="absolute top-0 left-0 w-full h-full object-cover z-[4]"
+        height={1961}
+        src={randomImage}
+        width={3840}
+      />
+      <div className="absolute z-[5] top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col items-center gap-4">
+        <div className="w-12 h-12 border-4 border-white border-t-transparent rounded-full animate-spin" />
+        <span className="text-xxl font-semibold text-white">{text}</span>
+      </div>
+      <div className="absolute bottom-12 left-1/2 -translate-x-1/2 z-[5] flex flex-col items-center gap-2">
+        <img
+          alt="How to play"
+          className="w-96 h-auto"
+          src={assetUrl("/images/how-to-play.webp")}
+        />
+        {!hideProgress && (
+          <Progress
+            disableAnimation
+            aria-label="Loading"
+            className="w-full"
+            value={progress}
+          />
+        )}
+      </div>
+    </div>
+  );
 };


### PR DESCRIPTION
## Summary
- show a spinning loader above the loading text

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686e817c4df88329b43297a49c9db0db