### PR TITLE
Load world model locally

### DIFF
--- a/client/next-js/public/models/README.md
+++ b/client/next-js/public/models/README.md
@@ -1,0 +1,2 @@
+This directory stores local 3D models for the game.
+Place `zone-fantasy-1.glb` here to load the world model locally.


### PR DESCRIPTION
## Summary
- load zone model with a local GLTFLoader
- add placeholder `public/models` folder with README

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_686e829216ac83298f75b7d8d7f0466b