### PR TITLE
Move profile lookup to websocket server

### DIFF
--- a/server/server.cjs
+++ b/server/server.cjs
@@ -804,6 +804,17 @@ ws.on('connection', (socket) => {
                 }));
                 break;
 
+            case 'GET_PROFILE':
+                if (message.address) {
+                    const profile = profiles[message.address] || null;
+                    socket.send(JSON.stringify({
+                        type: 'PROFILE',
+                        address: message.address,
+                        profile,
+                    }));
+                }
+                break;
+
             case 'CREATE_PROFILE':
                 if (message.address && message.nickname) {
                     profiles[message.address] = { nickname: message.nickname };


### PR DESCRIPTION
## Summary
- refactor `useProfile` hook to request the profile via WebSocket instead of querying the blockchain
- add `GET_PROFILE` handler to the game server so profiles can be requested from connected clients

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm test` in `client/next-js` *(fails: Missing script)*
- `npm test` in `server` *(fails: "Error: no test specified")*


------
https://chatgpt.com/codex/tasks/task_e_6871076c38048329ba3bc6222b5ebdd5