### PR TITLE
Add CSS crosshair indicator

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -1511,24 +1511,17 @@ export function Game({models, sounds, textures, matchId, character}) {
             if (!targetImage) return;
 
             if (!isFocused) {
-                targetImage.src = '/icons/target.svg';
+                targetImage.classList.remove('targeted');
+                targetImage.classList.add('not-targeted');
                 return;
             }
             const id = getTargetPlayer();
             if (id && players.has(id) && hasLineOfSight(id)) {
-                const start = playerCollider.start
-                    .clone()
-                    .add(playerCollider.end)
-                    .multiplyScalar(0.5);
-                const targetPos = players.get(id).model.position.clone();
-                const dist = start.distanceTo(targetPos);
-                if (dist <= FIREBLAST_RANGE) {
-                    targetImage.src = assetUrl('/icons/target-green.svg');
-                } else {
-                    targetImage.src = assetUrl('/icons/target.svg');
-                }
+                targetImage.classList.add('targeted');
+                targetImage.classList.remove('not-targeted');
             } else {
-                targetImage.src = assetUrl('/icons/target.svg');
+                targetImage.classList.remove('targeted');
+                targetImage.classList.add('not-targeted');
             }
         }
 

--- a/client/next-js/components/layout/Interface.css
+++ b/client/next-js/components/layout/Interface.css
@@ -109,3 +109,38 @@
     transform: translate(-50%, -50%) scale(1.3);
     transition: transform 0.2s ease-out;
 }
+
+.crosshair {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    border: 2px solid #fff;
+    border-radius: 50%;
+    box-sizing: border-box;
+    transition: transform 0.2s ease-out, border-color 0.2s ease-out, background-color 0.2s ease-out;
+}
+
+.crosshair::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 4px;
+    height: 4px;
+    background-color: #fff;
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+}
+
+.crosshair.not-targeted {
+    transform: scale(1.3);
+}
+
+.crosshair.targeted {
+    transform: scale(0.8);
+    border-color: #f00;
+}
+
+.crosshair.targeted::after {
+    background-color: #f00;
+}

--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -249,13 +249,7 @@ export const Interface = () => {
           zIndex: 1000,
         }}
       >
-        <Image
-          alt="Target"
-          height={25}
-          id="targetImage"
-          src={assetUrl("/icons/target.svg")}
-          width={25}
-        />
+        <div id="targetImage" className="crosshair not-targeted" />
       </div>
 
       <div className="self-damage-container" id="selfDamage" />


### PR DESCRIPTION
## Summary
- replace target image with CSS-based crosshair
- add styles for crosshair and targeted state
- update logic to toggle CSS classes for the crosshair

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint-plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68711441e9d08329a886573aa777d73a