### PR TITLE
Improve skin viewer

### DIFF
--- a/client/next-js/app/matches/[id]/page.tsx
+++ b/client/next-js/app/matches/[id]/page.tsx
@@ -385,13 +385,14 @@ export default function MatchesPage() {
                       </ul>
                     </div>
                   )}
-                  {selectedClassPreview && (
-                    <div className="mt-4 w-full flex items-center gap-2">
-                      <label className="text-sm">Skin:</label>
-                      <select
-                        className="text-black text-sm flex-1"
-                        value={selectedSkin || ''}
-                        onChange={(e) => setSelectedSkin(e.target.value)}
+                    {selectedClassPreview && (
+                      <div className="mt-4 w-full flex items-center gap-2">
+                        <label htmlFor="skin-select" className="text-sm">Skin:</label>
+                        <select
+                          id="skin-select"
+                          className="text-black text-sm flex-1"
+                          value={selectedSkin || ''}
+                          onChange={(e) => setSelectedSkin(e.target.value)}
                       >
                     {(CLASS_SKINS[selectedClassPreview as keyof typeof CLASS_SKINS] || []).map((s) => (
                       <option key={s} value={s}>

--- a/client/next-js/components/skin-viewer.tsx
+++ b/client/next-js/components/skin-viewer.tsx
@@ -6,6 +6,7 @@ import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader";
 import { DRACOLoader } from "three/examples/jsm/loaders/DRACOLoader";
 import { MeshoptDecoder } from "three/examples/jsm/libs/meshopt_decoder.module.js";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
+
 import { assetUrl } from "@/utilities/assets";
 
 export interface SkinViewerProps {
@@ -15,40 +16,67 @@ export interface SkinViewerProps {
 export function SkinViewer({ skin }: SkinViewerProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
+  const rendererRef = useRef<THREE.WebGLRenderer>();
+  const sceneRef = useRef<THREE.Scene>();
+  const cameraRef = useRef<THREE.PerspectiveCamera>();
+  const controlsRef = useRef<OrbitControls>();
+  const loaderRef = useRef<GLTFLoader>();
+  const currentModelRef = useRef<THREE.Object3D | null>(null);
+
+  // set up renderer and scene once
   useEffect(() => {
     const canvas = canvasRef.current;
-    if (!canvas || !skin) return;
 
-    const renderer = new THREE.WebGLRenderer({ canvas, alpha: true, antialias: true });
+    if (!canvas) return;
+
+    const renderer = new THREE.WebGLRenderer({
+      canvas,
+      alpha: true,
+      antialias: true,
+    });
+
     renderer.setPixelRatio(window.devicePixelRatio);
     renderer.setSize(canvas.clientWidth, canvas.clientHeight);
+    rendererRef.current = renderer;
 
     const scene = new THREE.Scene();
-    const camera = new THREE.PerspectiveCamera(45, canvas.clientWidth / canvas.clientHeight, 0.1, 100);
+
+    sceneRef.current = scene;
+
+    const camera = new THREE.PerspectiveCamera(
+      45,
+      canvas.clientWidth / canvas.clientHeight,
+      0.1,
+      100,
+    );
+
     camera.position.set(0, 1.2, 2.5);
+    cameraRef.current = camera;
 
     const hemi = new THREE.HemisphereLight(0xffffff, 0x444444, 1.5);
+
     scene.add(hemi);
+    const dir = new THREE.DirectionalLight(0xffffff, 1);
+
+    dir.position.set(5, 10, 7.5);
+    scene.add(dir);
 
     const controls = new OrbitControls(camera, renderer.domElement);
+
     controls.enablePan = false;
-    controls.enableZoom = false;
+    controls.enableZoom = true;
+    controlsRef.current = controls;
 
     const draco = new DRACOLoader();
+
     draco.setDecoderPath("/libs/draco/");
 
     const loader = new GLTFLoader();
+
     loader.setDRACOLoader(draco);
     loader.setMeshoptDecoder(MeshoptDecoder);
     loader.setPath(assetUrl("/models/skins/"));
-
-    let model: THREE.Object3D | null = null;
-
-    loader.load(`${skin}.glb`, (gltf) => {
-      model = gltf.scene;
-      model.rotation.y = Math.PI;
-      scene.add(model);
-    });
+    loaderRef.current = loader;
 
     const handleResize = () => {
       renderer.setSize(canvas.clientWidth, canvas.clientHeight);
@@ -64,6 +92,7 @@ export function SkinViewer({ skin }: SkinViewerProps) {
       controls.update();
       renderer.render(scene, camera);
     };
+
     animate();
 
     return () => {
@@ -72,10 +101,29 @@ export function SkinViewer({ skin }: SkinViewerProps) {
       draco.dispose();
       renderer.dispose();
     };
+  }, []);
+
+  // load model whenever skin changes
+  useEffect(() => {
+    if (!skin) return;
+    const loader = loaderRef.current;
+    const scene = sceneRef.current;
+
+    if (!loader || !scene) return;
+
+    loader.load(`${skin}.glb`, (gltf) => {
+      if (currentModelRef.current) {
+        scene.remove(currentModelRef.current);
+      }
+      const model = gltf.scene;
+
+      model.rotation.y = 0;
+      currentModelRef.current = model;
+      scene.add(model);
+    });
   }, [skin]);
 
   return <canvas ref={canvasRef} className="w-full h-48" />;
 }
 
 export default SkinViewer;
-


### PR DESCRIPTION
## Summary
- keep SkinViewer canvas around and swap models instead of re-rendering
- add ambient and directional light and enable zoom
- link skin select label to the select element

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68715dcddcac83298967a376141d3beb