### PR TITLE
Add logo to loading screen

### DIFF
--- a/client/next-js/components/loading.tsx
+++ b/client/next-js/components/loading.tsx
@@ -35,7 +35,7 @@ export const Loading = ({ text, hideProgress = false }: LoadingProps) => {
   }, []);
 
   return (
-    <div className="w-full h-full flex justify-center items-center">
+    <div className="relative w-full h-full flex justify-center items-center">
       <Image
         alt="Turtle Art"
         className="absolute top-0 left-0 w-full h-full object-cover z-[4]"
@@ -43,9 +43,16 @@ export const Loading = ({ text, hideProgress = false }: LoadingProps) => {
         src={randomImage}
         width={3840}
       />
+      <Image
+        alt="Logo"
+        className="absolute top-4 left-4 z-[5]"
+        height={48}
+        src="/logo_big.png"
+        width={48}
+      />
       <div className="absolute z-[5] top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col items-center gap-4">
-          <span className="text-xxl font-semibold text-white">{text}</span>
-          <div className="w-6 h-6 border-4 border-white border-t-transparent rounded-full animate-spin" />
+        <span className="text-xxl font-semibold text-white">{text}</span>
+        <div className="w-6 h-6 border-4 border-white border-t-transparent rounded-full animate-spin" />
       </div>
       <div className="absolute bottom-12 left-1/2 -translate-x-1/2 z-[5] flex flex-col items-center gap-2">
         <img


### PR DESCRIPTION
## Summary
- show the small site logo at top-left of the loading overlay

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872e02eac148329a0c9be3c6ff583fd