### PR TITLE
Remove redundant model scales map

### DIFF
--- a/client/next-js/app/matches/[id]/game/page.tsx
+++ b/client/next-js/app/matches/[id]/game/page.tsx
@@ -136,21 +136,22 @@ export default function GamePage() {
 
     const models = [
         {id: "zone", path: "zone-fantasy-1.glb", local: true},
-        {id: "bolvar", path: "skins/bolvar.glb"},
-        {id: "mad", path: "skins/mad.glb"},
-        {id: "brand", path: "skins/brand.glb", local: true},
-        {id: "aurelion", path: "skins/aurelion.glb", local: true},
-        {id: "annie", path: "skins/annie.glb", local: true},
-        {id: "fizz", path: "skins/fizz.glb", local: true},
-        {id: "karthus", path: "skins/karthus.glb", local: true},
-        {id: "darius", path: "skins/darius.glb", local: true},
-        {id: "kayn", path: "skins/kayn.glb", local: true},
-        {id: "akali", path: "skins/akali.glb", local: true},
-        {id: "galio", path: "skins/galio.glb", local: true},
+        {id: "bolvar", path: "skins/bolvar.glb", scale: 0.00665},
+        {id: "mad", path: "skins/mad.glb", scale: 0.00665},
+        {id: "brand", path: "skins/brand.glb", local: true, scale: 0.00665},
+        {id: "aurelion", path: "skins/aurelion.glb", local: true, scale: 0.00665},
+        {id: "annie", path: "skins/annie.glb", local: true, scale: 0.00665},
+        {id: "fizz", path: "skins/fizz.glb", local: true, scale: 0.00665},
+        {id: "karthus", path: "skins/karthus.glb", local: true, scale: 0.00665},
+        {id: "darius", path: "skins/darius.glb", local: true, scale: 0.00665},
+        {id: "kayn", path: "skins/kayn.glb", local: true, scale: 0.00665},
+        {id: "akali", path: "skins/akali.glb", local: true, scale: 0.00665},
+        {id: "galio", path: "skins/galio.glb", local: true, scale: 0.00665},
         {
             id: "character",
             path: `skins/${charSkin}.glb`,
-            local: true
+            local: true,
+            scale: 0.00665
         },
         {id: "heal-effect", path: "heal-effect.glb"},
         {id: "bottle_magic", path: "bottle_magic.glb"},
@@ -175,6 +176,7 @@ export default function GamePage() {
                         model.path,
                         (gltf) => {
                             loadedModels[model.id] = gltf.scene;
+                            loadedModels[model.id].userData.scale = model.scale ?? 0.00665;
                             if (gltf.animations) {
                                 loadedModels[`${model.id}_animations`] = gltf.animations;
                             }

--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -398,10 +398,13 @@ export function Game({models, sounds, textures, matchId, character}) {
             if (!models[newModelName]) return;
             const playerData = players.get(myPlayerId);
             const oldModel = playerData.model;
-            const newModel = models[newModelName].clone();
+            const base = models[newModelName];
+            const defaultScale = base.userData?.scale ?? 0.00665;
+            const newModel = base.clone();
             newModel.position.copy(oldModel.position);
             newModel.rotation.copy(oldModel.rotation);
-            newModel.scale.set(currentScale, currentScale, currentScale);
+            newModel.scale.set(defaultScale, defaultScale, defaultScale);
+            currentScale = defaultScale;
             newModel.traverse((obj) => { if (obj.isMesh) obj.castShadow = true; });
             scene.remove(oldModel);
             scene.add(newModel);
@@ -3538,10 +3541,14 @@ export function Game({models, sounds, textures, matchId, character}) {
         function createPlayer(id, name = "", address = "", classType = "", characterModel = "vampir") {
             const baseModel = models[characterModel] || models['character'];
             if (baseModel) {
+                const defaultScale = baseModel.userData?.scale ?? 0.00665;
                 const player = SkeletonUtils.clone(baseModel);
                 player.position.set(...USER_DEFAULT_POSITION);
 
-                player.scale.set(currentScale, currentScale, currentScale);
+                player.scale.set(defaultScale, defaultScale, defaultScale);
+                if (id === myPlayerId) {
+                    currentScale = defaultScale;
+                }
                 player.rotation.set(0, 0, 0);
 
                 player.traverse((object) => {


### PR DESCRIPTION
## Summary
- rely on `scale` value embedded in `page.tsx` models
- drop `MODEL_SCALES` constant and related lookups

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6876bfdb461c8329a1de62467f30e24b