### PR TITLE
Add dance animation triggered by Alt+3

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -1143,6 +1143,21 @@ export function Game({models, sounds, textures, matchId, character}) {
                 `Looking direction: x=${lookDir.x}, y=${lookDir.y}, z=${lookDir.z}`,
             );
         }
+        function handleDanceStart() {
+            const { mixer, actions } = players.get(myPlayerId);
+            const actionName = 'dance';
+            controlAction({
+                action: actions[actionName],
+                actionName,
+                mixer,
+                loop: THREE.LoopRepeat,
+                fadeIn: 0.2,
+                reset: true,
+            });
+        }
+        function handleDanceStop() {
+            setAnimation('idle');
+        }
         function handleKeyT() {
             dispatch({type: 'SET_SCOREBOARD_VISIBLE', payload: true});
         }
@@ -1207,6 +1222,11 @@ export function Game({models, sounds, textures, matchId, character}) {
                 handleEscape();
                 return;
             }
+            if (event.altKey && event.code === "Digit3") {
+                handleDanceStart();
+                keyStates[event.code] = true;
+                return;
+            }
             if (event.code === "Enter") {
                 if (!isChatActive) {
                     chatInputElement.focus();
@@ -1248,6 +1268,10 @@ export function Game({models, sounds, textures, matchId, character}) {
             if (isChatActive) return;
 
             if (!controlsEnabled || debuffsRef.current.some(d => d.type === 'stun') || menuVisibleRef.current) return;
+
+            if (event.code === "Digit3" || event.code === "AltLeft" || event.code === "AltRight") {
+                handleDanceStop();
+            }
 
             keyStates[event.code] = false;
 
@@ -3556,6 +3580,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                 hitReaction: get(map.hitReaction),
                 attack: get(map.attack),
                 attack360: get(map.attack360),
+                dance: get(map.dance),
                 hook: get(map.hook),
             };
 

--- a/client/next-js/consts/skinAnimations.ts
+++ b/client/next-js/consts/skinAnimations.ts
@@ -12,6 +12,7 @@ export interface AnimationMap {
   hitReaction: string;
   attack: string;
   attack360: string;
+  dance: string;
   hook?: string;
 }
 
@@ -31,5 +32,3 @@ export const SKIN_ANIMATIONS: Record<string, AnimationMap> = {
   kayn: createDefaultMap("kayn"),
   galio: createDefaultMap("galio"),
 };
-
-

--- a/client/next-js/consts/skinSkillMap.json
+++ b/client/next-js/consts/skinSkillMap.json
@@ -10,7 +10,8 @@
     "dying": "annie_2012_death.anm",
     "hitReaction": "hit_reaction",
     "attack": "annie_2012_attack1.anm",
-    "attack360": "attack_360"
+    "attack360": "attack_360",
+    "dance": "annie_2012_dance_loop.anm"
   },
   "kayn": {
     "idle": "Kayn_Idle1_loop",
@@ -23,7 +24,8 @@
     "dying": "kayn_death",
     "hitReaction": "",
     "attack": "Kayn_Attack2",
-    "attack360": "Kayn_Spell1_Circle"
+    "attack360": "Kayn_Spell1_Circle",
+    "dance": "kayn_dance.anm"
   },
   "fizz": {
     "idle": "fizz_idle1.anm",
@@ -36,7 +38,8 @@
     "dying": "fizz_death.anm",
     "hitReaction": "hit_reaction",
     "attack": "fizz_attack1.anm",
-    "attack360": "attack_360"
+    "attack360": "attack_360",
+    "dance": "fizz_dance.anm"
   },
   "karthus": {
     "idle": "karthus_idle1.anm",
@@ -49,7 +52,8 @@
     "dying": "karthus_death.anm",
     "hitReaction": "hit_reaction",
     "attack": "karthus_attack1.anm",
-    "attack360": "attack_360"
+    "attack360": "attack_360",
+    "dance": "karthus_dance_loop.anm"
   },
   "brand": {
     "idle": "brand_idle1.anm",
@@ -62,7 +66,8 @@
     "dying": "brand_death.anm",
     "hitReaction": "hit_reaction",
     "attack": "brand_attack1.anm",
-    "attack360": "attack_360"
+    "attack360": "attack_360",
+    "dance": "brand_dance.anm"
   },
   "darius": {
     "idle": "darius_idle1.anm",
@@ -76,7 +81,8 @@
     "hitReaction": "hit_reaction",
     "attack": "darius_attack1.anm",
     "attack360": "darius_spell1.anm",
-    "hook": "darius_spell3.anm"
+    "hook": "darius_spell3.anm",
+    "dance": "darius_dance.anm"
   },
   "aurelion": {
     "idle": "aurelionsol_idle1.anm",
@@ -89,7 +95,8 @@
     "dying": "aurelionsol_death.anm",
     "hitReaction": "hit_reaction",
     "attack": "aurelionsol_attack1.anm",
-    "attack360": "attack_360"
+    "attack360": "attack_360",
+    "dance": "aurelionsol_danceloop.anm"
   },
   "akali": {
     "idle": "akali_idle1.anm",
@@ -102,7 +109,8 @@
     "dying": "akali_death.anm",
     "hitReaction": "hit_reaction",
     "attack": "akali_base_attack1_to_run2",
-    "attack360": "attack_360"
+    "attack360": "attack_360",
+    "dance": "Dance"
   },
   "galio": {
     "idle": "galio_idle1.anm",
@@ -115,6 +123,7 @@
     "dying": "galio_death.anm",
     "hitReaction": "hit_reaction",
     "attack": "galio_attack01.anm",
-    "attack360": "attack_360"
+    "attack360": "attack_360",
+    "dance": "galio_dance_loop.anm"
   }
 }


### PR DESCRIPTION
## Summary
- map dance animations for all skins
- expose `dance` in AnimationMap constants
- load `dance` clip in game action builder
- trigger dance animation on Alt+3 press and return to idle on release

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6878b4aee4248329be3c7ed512abff82