### PR TITLE
Fix double damage display on player

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -4292,8 +4292,13 @@ export function Game({models, sounds, textures, matchId, character}) {
                     break;
                 }
                 case "DAMAGE":
-                    if (message.targetId && (message.targetId === myPlayerId || message.dealerId === myPlayerId)) {
-                        showDamage(message.targetId, message.amount, message.spellType);
+                    if (
+                        message.targetId &&
+                        (message.targetId === myPlayerId || message.dealerId === myPlayerId)
+                    ) {
+                        if (message.targetId !== myPlayerId) {
+                            showDamage(message.targetId, message.amount, message.spellType);
+                        }
                         if (message.targetId === myPlayerId) {
                             showSelfDamage(message.amount);
                             sounds.damage.volume = 0.5;


### PR DESCRIPTION
## Summary
- avoid showing floating damage numbers on self along with UI damage text

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6878be1ebd2c83298f55465d5755c048