### PR TITLE
Add keyboard hints overlay

### DIFF
--- a/client/next-js/components/layout/Interface.tsx
+++ b/client/next-js/components/layout/Interface.tsx
@@ -1,5 +1,6 @@
 import { Progress } from "@heroui/react";
 
+import { KeyboardHints } from "../parts/KeyboardHints.jsx";
 import { SkillBar } from "../parts/SkillBar.jsx";
 import { CastBar } from "../parts/CastBar.jsx";
 import { Chat } from "../parts/Chat.jsx";
@@ -17,9 +18,6 @@ import { CLASS_ICONS } from "@/consts/classes";
 
 import "./Interface.css";
 import Image from "next/image";
-
-import { assetUrl } from "@/utilities/assets";
-
 import React, { useEffect, useState } from "react";
 
 import { MAX_HP, MAX_MANA } from "../../consts";
@@ -171,7 +169,8 @@ export const Interface = () => {
                   : "Mana"
               }
               color={
-                character.classType === "rogue" || character.classType === "warrior"
+                character.classType === "rogue" ||
+                character.classType === "warrior"
                   ? "warning"
                   : "primary"
               }
@@ -257,7 +256,7 @@ export const Interface = () => {
           zIndex: 1000,
         }}
       >
-        <div id="targetImage" className="crosshair not-targeted" />
+        <div className="crosshair not-targeted" id="targetImage" />
       </div>
 
       <div className="self-damage-container" id="selfDamage" />
@@ -276,6 +275,7 @@ export const Interface = () => {
       <ExperienceBar />
       <LevelUp />
       <KillNotification />
+      <KeyboardHints />
       <Chat />
     </div>
   );

--- a/client/next-js/components/parts/KeyboardHints.css
+++ b/client/next-js/components/parts/KeyboardHints.css
@@ -1,0 +1,18 @@
+.keyboard-hints {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 1000;
+  background-color: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  padding: 6px 8px;
+  font-size: 12px;
+  border-radius: 6px;
+  line-height: 1.2;
+  pointer-events: none;
+}
+
+.keyboard-hints p {
+  margin: 0;
+}
+

--- a/client/next-js/components/parts/KeyboardHints.jsx
+++ b/client/next-js/components/parts/KeyboardHints.jsx
@@ -1,0 +1,16 @@
+import './KeyboardHints.css';
+
+export const KeyboardHints = () => (
+  <div className="keyboard-hints">
+    <p>WASD - move</p>
+    <p>Space - jump</p>
+    <p>Left click - attack</p>
+    <p>Right click - target mode</p>
+    <p>Q/E/R/F - skills</p>
+    <p>T - scoreboard</p>
+    <p>C - stats</p>
+    <p>Enter - chat</p>
+    <p>Esc - menu</p>
+  </div>
+);
+


### PR DESCRIPTION
## Summary
- add `KeyboardHints` component with compact keymap overlay
- style overlay for small transparent help box
- include `KeyboardHints` in game interface

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68793f0246a88329b3d7210bc21b088c