### PR TITLE
Fix E attack animation

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -1990,6 +1990,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                 clampWhenFinished: true,
                 onEnd: () => {
                     attack.timeScale = originalScale;
+                    setAnimation('idle');
                 },
             });
 
@@ -2043,6 +2044,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                 clampWhenFinished: true,
                 onEnd: () => {
                     attack.timeScale = originalScale;
+                    setAnimation('idle');
                 },
             });
 


### PR DESCRIPTION
## Summary
- ensure Light Strike and Savage Blow animations restore idle state

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b89efaa948329913804771b12d1b0