### PR TITLE
Improve speed skill animations

### DIFF
--- a/client/next-js/components/game.jsx
+++ b/client/next-js/components/game.jsx
@@ -366,6 +366,7 @@ export function Game({models, sounds, textures, matchId, character}) {
 
 
         let movementSpeedModifier = 1; // Normal speed
+        let speedBuffActive = false;
 
         const damageBar = document.getElementById("damage");
         const selfDamage = document.getElementById("selfDamage");
@@ -1106,13 +1107,16 @@ export function Game({models, sounds, textures, matchId, character}) {
         const chatInputElement = document.getElementById("chat-input");
 
         function handleKeyW() {
-            !isCasting && !isActionRunning(PRIORITY_ACTIONS) && setAnimation("walk");
+            !isCasting && !isActionRunning(PRIORITY_ACTIONS) &&
+                setAnimation(speedBuffActive ? "run" : "walk");
         }
         function handleKeyA() {
-            !isCasting && !isActionRunning(PRIORITY_ACTIONS) && setAnimation("walk");
+            !isCasting && !isActionRunning(PRIORITY_ACTIONS) &&
+                setAnimation(speedBuffActive ? "run" : "walk");
         }
         function handleKeyD() {
-            !isCasting && !isActionRunning(PRIORITY_ACTIONS) && setAnimation("walk");
+            !isCasting && !isActionRunning(PRIORITY_ACTIONS) &&
+                setAnimation(speedBuffActive ? "run" : "walk");
         }
         function handleKeyS() {
             !isCasting && !isActionRunning(PRIORITY_ACTIONS) && setAnimation("idle");
@@ -1789,6 +1793,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                         sounds,
                     });
                     applySpeedEffect(playerId, 5000, 2);
+                    spawnSprintTrail(playerId, 5000);
                     break;
                 case "paladin-heal":
                     castPaladinHeal({
@@ -1846,6 +1851,8 @@ export function Game({models, sounds, textures, matchId, character}) {
                         startSkillCooldown,
                         sounds,
                     });
+                    applySpeedEffect(playerId, 8000);
+                    spawnSprintTrail(playerId, 8000);
                     break;
                 case "sprint":
                     castSprint({
@@ -2384,12 +2391,12 @@ export function Game({models, sounds, textures, matchId, character}) {
             // Rotate the camera horizontally using A and D instead of strafing
             if (keyStates["KeyA"]) {
                 playerVelocity.add(getSideVector().multiplyScalar(-speedDelta));
-                if (!isAnyActionRunning()) setAnimation("walk");
+                if (!isAnyActionRunning()) setAnimation(speedBuffActive ? "run" : "walk");
             }
 
             if (keyStates["KeyD"]) {
                 playerVelocity.add(getSideVector().multiplyScalar(speedDelta));
-                if (!isAnyActionRunning()) setAnimation("walk");
+                if (!isAnyActionRunning()) setAnimation(speedBuffActive ? "run" : "walk");
             }
 
             if (keyStates["KeyW"]) {
@@ -2435,7 +2442,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                     Math.cos(y),
                 );
                 playerVelocity.add(forwardVector.multiplyScalar(speedDelta));
-                if (!isAnyActionRunning()) setAnimation("walk");
+                if (!isAnyActionRunning()) setAnimation(speedBuffActive ? "run" : "walk");
             }
 
             if (keyStates["KeyS"]) {
@@ -2446,7 +2453,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                 );
 
                 playerVelocity.add(backwardVector.multiplyScalar(speedDelta));
-                if (!isAnyActionRunning()) setAnimation("walk");
+                if (!isAnyActionRunning()) setAnimation(speedBuffActive ? "run" : "walk");
             }
         }
 
@@ -2945,7 +2952,11 @@ export function Game({models, sounds, textures, matchId, character}) {
         function applySpeedEffect(playerId, duration = 5000, multiplier = 1.4) {
             if (playerId === myPlayerId) {
                 movementSpeedModifier = multiplier;
-                setTimeout(() => (movementSpeedModifier = 1), duration);
+                speedBuffActive = true;
+                setTimeout(() => {
+                    movementSpeedModifier = 1;
+                    speedBuffActive = false;
+                }, duration);
             }
         }
 
@@ -4126,6 +4137,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                         case "divine-speed":
                             if (message.id === myPlayerId) {
                                 applySpeedEffect(myPlayerId, 5000, 2);
+                                spawnSprintTrail(myPlayerId, 5000);
                             }
                             break;
                         case "blood-strike":
@@ -4158,6 +4170,7 @@ export function Game({models, sounds, textures, matchId, character}) {
                         case "adrenaline-rush":
                             if (message.id === myPlayerId) {
                                 applySpeedEffect(myPlayerId, 8000);
+                                spawnSprintTrail(myPlayerId, 8000);
                             }
                             break;
                         case "sprint":


### PR DESCRIPTION
## Summary
- enhance sprint visuals for Rogue and Paladin
- switch to run animation when a speed buff is active

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b8a0c77808329800b25bb4f8cee74