### PR TITLE
Add skin display names

### DIFF
--- a/client/next-js/app/matches/[id]/page.tsx
+++ b/client/next-js/app/matches/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
   CLASS_MODELS,
   CLASS_SKINS,
   CLASS_STATS,
+  SKIN_NAMES,
   MAX_HP,
   MAX_MANA,
 } from "@/consts";
@@ -431,7 +432,8 @@ export default function MatchesPage() {
             <div className="flex flex-col items-center w-full text-white">
               {selectedSkin && (
                 <Image
-                  alt={selectedSkin}
+                  alt={SKIN_NAMES[selectedSkin as keyof typeof SKIN_NAMES] ||
+                    selectedSkin}
                   className="w-[200] h-[350]"
                   height={500}
                   src={`/images/skins/${selectedSkin}.webp`}
@@ -446,7 +448,10 @@ export default function MatchesPage() {
                 >
                   <ArrowLeftIcon size={20} />
                 </Button>
-                <span className="font-bold text-lg">{selectedSkin}</span>
+                <span className="font-bold text-lg">
+                  {SKIN_NAMES[selectedSkin as keyof typeof SKIN_NAMES] ||
+                    selectedSkin}
+                </span>
                 <Button
                   isDisabled={
                     skinIndex ===

--- a/client/next-js/app/matches/[id]/summary/page.tsx
+++ b/client/next-js/app/matches/[id]/summary/page.tsx
@@ -14,6 +14,7 @@ import { useParams, useRouter } from "next/navigation";
 import { ButtonWithSound as Button } from "@/components/button-with-sound";
 import { useWS } from "@/hooks/useWS";
 import { Navbar } from "@/components/navbar";
+import { SKIN_NAMES } from "@/consts";
 
 interface PlayerSummary {
   id: number;
@@ -83,7 +84,12 @@ export default function MatchSummaryPage() {
                   <TableCell>{p.reward}</TableCell>
                   <TableCell>{p.coins}</TableCell>
                   <TableCell>
-                    {p.item ? `${p.item.skin} ${p.item.class}` : "-"}
+                    {p.item
+                      ? `${
+                          SKIN_NAMES[p.item.skin as keyof typeof SKIN_NAMES] ||
+                          p.item.skin
+                        } ${p.item.class}`
+                      : "-"}
                   </TableCell>
                   <TableCell>{p.rankDelta}</TableCell>
                 </TableRow>

--- a/client/next-js/consts/index.ts
+++ b/client/next-js/consts/index.ts
@@ -16,5 +16,6 @@ export { default as SPELL_COST } from "./spellCosts.json";
 export { default as CLASS_MODELS } from "./classModels.json";
 export { default as CLASS_SKINS } from "./classSkins.json";
 export * from "./skinAnimations";
+export { default as SKIN_NAMES } from "./skinNames";
 export { default as CLASS_STATS } from "./classStats.json";
 export * from "./melee";

--- a/client/next-js/consts/skinNames.ts
+++ b/client/next-js/consts/skinNames.ts
@@ -1,0 +1,12 @@
+export const SKIN_NAMES: Record<string, string> = {
+  brand: "Hephaestus",
+  aurelion: "Sol Invictus",
+  enya: "Hestia",
+  fizz: "Poseidon",
+  galio: "Atlas",
+  yassuo: "Aeolus",
+  darius: "Ares",
+  kayn: "Hades",
+};
+
+export default SKIN_NAMES;


### PR DESCRIPTION
## Summary
- add a new constant map for display skin names
- show mapped names during skin selection and in match summary

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_687bd21a1a448329b57c740cfbf74745